### PR TITLE
Feature: Add Flags `maxConcurrentTests` (and `version`) to allow for concurrent test execution. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
   jq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-COPY --from=builder bin/assertoor /assertoor
+COPY --from=builder /src/bin/assertoor /assertoor
 ENTRYPOINT ["/assertoor"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 			logr.SetLevel(logrus.DebugLevel)
 		}
 
-		coord := coordinator.NewCoordinator(config, logr, metricsPort)
+		coord := coordinator.NewCoordinator(config, logr, metricsPort, concurrency)
 
 		if err := coord.Run(cmd.Context()); err != nil {
 			log.Fatal(err)
@@ -45,6 +45,7 @@ var (
 	logFormat   string
 	verbose     bool
 	metricsPort int
+	concurrency int
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -62,6 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "log format (default is text). Valid values are 'text', 'json'")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
-
+	rootCmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of tests to run concurrently")
 	rootCmd.Flags().IntVarP(&metricsPort, "metrics-port", "", 9090, "Port to serve Prometheus metrics on")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if version {
-			log.Printf("Local build; Unknown version\n")
+			log.Print("Local build; Unknown version\n")
 			return
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -17,17 +16,17 @@ var rootCmd = &cobra.Command{
 	Short: "Runs a configured test until completion or error",
 	Run: func(cmd *cobra.Command, _ []string) {
 		if version && buildinfo.BuildRelease != "" {
-			fmt.Printf("Release: %s\n", buildinfo.BuildRelease)
+			log.Printf("Release: %s\n", buildinfo.BuildRelease)
 			return
 		}
 
 		if version && buildinfo.BuildVersion != "" {
-			fmt.Printf("Version: %s\n", buildinfo.BuildVersion)
+			log.Printf("Version: %s\n", buildinfo.BuildVersion)
 			return
 		}
 
 		if version {
-			fmt.Printf("Local build; Unknown version\n")
+			log.Printf("Local build; Unknown version\n")
 			return
 		}
 


### PR DESCRIPTION
This PR adds the possibility to configure the amount of tests that can run concurrently. It adds a semaphore to limit the number of concurrent tests that can be executed to the value provided by the `maxConcurrentTests` flag. By default the `maxConcurrentTests` flag is set to 1, which means tests are executed sequentially.