### PR TITLE
Improve logging

### DIFF
--- a/pkg/coordinator/clients/consensus/rpc/eventstream/eventstream.go
+++ b/pkg/coordinator/clients/consensus/rpc/eventstream/eventstream.go
@@ -188,10 +188,9 @@ func (stream *Stream) receiveEvents(r io.ReadCloser) {
 			return
 		}
 
-		stream.closeMutex.Unlock()
-
 		pub, ok := ev.(StreamEvent)
 		if !ok {
+			stream.closeMutex.Unlock()
 			continue
 		}
 
@@ -204,6 +203,7 @@ func (stream *Stream) receiveEvents(r io.ReadCloser) {
 		}
 
 		stream.Events <- pub
+		stream.closeMutex.Unlock()
 	}
 }
 

--- a/pkg/coordinator/tasks/check_consensus_forks/task.go
+++ b/pkg/coordinator/tasks/check_consensus_forks/task.go
@@ -116,7 +116,11 @@ func (t *Task) runCheck() types.TaskResult {
 		t.logger.Warnf("check failed: too many forks. (have: %v, want <= %v)", len(headForks)-1, t.config.MaxForkCount)
 
 		for idx, fork := range headForks {
-			t.logger.Infof("Fork #%v: %v [0x%x] (%v clients)", idx, fork.Slot, fork.Root, len(fork.AllClients))
+			clients := make([]string, len(fork.AllClients))
+			for _, client := range fork.AllClients {
+				clients = append(clients, client.GetName())
+			}
+			t.logger.Infof("Fork #%v: %v [0x%x] (%v clients: [%v])", idx, fork.Slot, fork.Root, len(fork.AllClients), clients)
 		}
 
 		return types.TaskResultFailure

--- a/pkg/coordinator/tasks/check_consensus_forks/task.go
+++ b/pkg/coordinator/tasks/check_consensus_forks/task.go
@@ -120,6 +120,7 @@ func (t *Task) runCheck() types.TaskResult {
 			for _, client := range fork.AllClients {
 				clients = append(clients, client.GetName())
 			}
+
 			t.logger.Infof("Fork #%v: %v [0x%x] (%v clients: [%v])", idx, fork.Slot, fork.Root, len(fork.AllClients), clients)
 		}
 

--- a/pkg/coordinator/test/descriptor.go
+++ b/pkg/coordinator/test/descriptor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -45,22 +46,29 @@ func LoadTestDescriptors(ctx context.Context, localTests []*types.TestConfig, ex
 		testID := ""
 
 		testConfig, err := loadExternalTestConfig(ctx, extTestCfg)
-		if err == nil {
-			if extTestCfg.Name != "" {
-				testConfig.Name = extTestCfg.Name
-			}
+		if err != nil || testConfig == nil {
+			logrus.Errorf("error loading external test %v: %v", extTestCfg.File, err)
+			return nil
+		}
 
-			if extTestCfg.Timeout != nil {
-				testConfig.Timeout = *extTestCfg.Timeout
-			}
+		if extTestCfg.Name != "" {
+			testConfig.Name = extTestCfg.Name
+		}
 
-			for k, v := range extTestCfg.Config {
-				testConfig.Config[k] = v
-			}
+		if extTestCfg.Timeout != nil {
+			testConfig.Timeout = *extTestCfg.Timeout
+		}
 
-			for k, v := range extTestCfg.ConfigVars {
-				testConfig.ConfigVars[k] = v
-			}
+		for k, v := range extTestCfg.Config {
+			testConfig.Config[k] = v
+		}
+
+		for k, v := range extTestCfg.ConfigVars {
+			testConfig.ConfigVars[k] = v
+		}
+
+		if testConfig.ID != "" {
+			testID = testConfig.ID
 		}
 
 		if testID == "" {

--- a/pkg/coordinator/test/test.go
+++ b/pkg/coordinator/test/test.go
@@ -27,7 +27,7 @@ type Test struct {
 func CreateTest(runID uint64, descriptor types.TestDescriptor, logger logrus.FieldLogger, services types.TaskServices, variables types.Variables) (types.Test, error) {
 	test := &Test{
 		runID:      runID,
-		logger:     logger.WithField("RunID", runID),
+		logger:     logger.WithField("RunID", runID).WithField("TestID", descriptor.ID()),
 		descriptor: descriptor,
 		config:     descriptor.Config(),
 		status:     types.TestStatusPending,

--- a/pkg/coordinator/test/test.go
+++ b/pkg/coordinator/test/test.go
@@ -167,6 +167,7 @@ func (t *Test) Run(ctx context.Context) error {
 }
 
 func (t *Test) AbortTest(skipCleanup bool) {
+	t.logger.Info("aborting test")
 	t.status = types.TestStatusAborted
 
 	if t.taskScheduler != nil {


### PR DESCRIPTION
This PR fixes 
- a panic:
```
[      2253.808] [ service_assertoor-0] [inf] panic: send on closed channel
[      2253.809] [ service_assertoor-0] [inf] 
[      2253.819] [ service_assertoor-0] [inf] goroutine 137 [running]:
[      2253.839] [ service_assertoor-0] [inf] github.com/ethpandaops/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream.(*Stream).receiveEvents(0xc000ee4ae0, {0x14ded58?, 0xc000ef41c0})
[      2253.842] [ service_assertoor-0] [inf] 	/git/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream/eventstream.go:206 +0x305
[      2253.842] [ service_assertoor-0] [inf] github.com/ethpandaops/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream.(*Stream).stream(0xc000ee4ae0, {0x14ded58?, 0xc000ef41c0})
[      2253.842] [ service_assertoor-0] [inf] 	/git/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream/eventstream.go:166 +0x8f
[      2253.842] [ service_assertoor-0] [inf] created by github.com/ethpandaops/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream.SubscribeWith in goroutine 136
[      2253.842] [ service_assertoor-0] [inf] 	/git/assertoor/pkg/coordinator/clients/consensus/rpc/eventstream/eventstream.go:96 +0x1c5
```

- It also improves logging by adding the test ID to test logs additionally to the run ID.

- It adds the list of clients to the fork check output