### PR TITLE
fix panic when no execution client is available

### DIFF
--- a/pkg/coordinator/wallet/wallet.go
+++ b/pkg/coordinator/wallet/wallet.go
@@ -287,9 +287,23 @@ func (wallet *Wallet) AwaitTransaction(ctx context.Context, tx *types.Transactio
 		}
 	}
 
-	client := wallet.manager.clientPool.GetCanonicalFork(0).ReadyClients[0]
+	retryCount := 3
+	var headFork *execution.HeadFork
 
-	return client.GetRPCClient().GetTransactionReceipt(ctx, txHash)
+	for retryCount > 0 {
+		headFork = wallet.manager.clientPool.GetCanonicalFork(0)
+		if headFork != nil && headFork.ReadyClients != nil && len(headFork.ReadyClients) > 0 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+		retryCount -= 1
+	}
+
+	if headFork == nil || headFork.ReadyClients == nil || len(headFork.ReadyClients) == 0 {
+		return nil, fmt.Errorf("no ready clients currently are available")
+	}
+
+	return headFork.ReadyClients[0].GetRPCClient().GetTransactionReceipt(ctx, txHash)
 }
 
 func (wallet *Wallet) getTxNonceChan(targetNonce uint64) *nonceStatus {

--- a/pkg/coordinator/wallet/wallet.go
+++ b/pkg/coordinator/wallet/wallet.go
@@ -288,15 +288,17 @@ func (wallet *Wallet) AwaitTransaction(ctx context.Context, tx *types.Transactio
 	}
 
 	retryCount := 3
+
 	var headFork *execution.HeadFork
 
 	for retryCount > 0 {
 		headFork = wallet.manager.clientPool.GetCanonicalFork(0)
+
 		if headFork != nil && headFork.ReadyClients != nil && len(headFork.ReadyClients) > 0 {
 			break
 		}
 		time.Sleep(2 * time.Second)
-		retryCount -= 1
+		retryCount--
 	}
 
 	if headFork == nil || headFork.ReadyClients == nil || len(headFork.ReadyClients) == 0 {


### PR DESCRIPTION
Bug found using [Antithesis](https://antithesis.com)

```
panic: runtime error: index out of range [0] with length 0
1747.690service_assertoor-0 info
1747.694service_assertoor-0 info
goroutine 6018 [running]:
1747.697service_assertoor-0 info
github.com/ethpandaops/assertoor/pkg/coordinator/wallet.(*Wallet).AwaitTransaction(0xc000d8e880, {0x14ef548, 0xc00047a370}, 0xc0010cd440)
1747.697service_assertoor-0 info
	/git/assertoor/pkg/coordinator/wallet/wallet.go:290 +0x1f8
1747.697service_assertoor-0 info
github.com/ethpandaops/assertoor/pkg/coordinator/tasks/generate_eoa_transactions.(*Task).generateTransaction.func2()
1747.697service_assertoor-0 info
	/git/assertoor/pkg/coordinator/tasks/generate_eoa_transactions/task.go:401 +0x3e
1747.697service_assertoor-0 info
created by github.com/ethpandaops/assertoor/pkg/coordinator/tasks/generate_eoa_transactions.(*Task).generateTransaction in goroutine 5863
1747.697service_assertoor-0 info
	/git/assertoor/pkg/coordinator/tasks/generate_eoa_transactions/task.go:400 +0x749
1748.213container_events info
Unexpected container shutdown detected: container=assertoor-0  exit_code=2
```