### PR TITLE
Task scheduler improvements

### DIFF
--- a/pkg/coordinator/clients/consensus/block_utils.go
+++ b/pkg/coordinator/clients/consensus/block_utils.go
@@ -31,3 +31,21 @@ func GetExecutionExtraData(v *spec.VersionedSignedBeaconBlock) ([]byte, error) {
 		return nil, errors.New("unknown version")
 	}
 }
+
+func GetBlockBody(v *spec.VersionedSignedBeaconBlock) any {
+	//nolint:exhaustive // ignore
+	switch v.Version {
+	case spec.DataVersionPhase0:
+		return v.Phase0
+	case spec.DataVersionAltair:
+		return v.Altair
+	case spec.DataVersionBellatrix:
+		return v.Bellatrix
+	case spec.DataVersionCapella:
+		return v.Capella
+	case spec.DataVersionDeneb:
+		return v.Deneb
+	default:
+		return nil
+	}
+}

--- a/pkg/coordinator/scheduler/scheduler.go
+++ b/pkg/coordinator/scheduler/scheduler.go
@@ -2,14 +2,10 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
-	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/ethpandaops/assertoor/pkg/coordinator/logger"
-	"github.com/ethpandaops/assertoor/pkg/coordinator/tasks"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
 	"github.com/sirupsen/logrus"
 )
@@ -18,34 +14,15 @@ type TaskScheduler struct {
 	services         types.TaskServices
 	logger           logrus.FieldLogger
 	rootVars         types.Variables
-	taskCount        uint64
-	allTasks         []types.Task
-	rootTasks        []types.Task
-	allCleanupTasks  []types.Task
-	rootCleanupTasks []types.Task
+	taskCount        types.TaskIndex
+	allTasks         []types.TaskIndex
+	rootTasks        []types.TaskIndex
+	allCleanupTasks  []types.TaskIndex
+	rootCleanupTasks []types.TaskIndex
 	taskStateMutex   sync.RWMutex
-	taskStateMap     map[types.Task]*taskExecutionState
+	taskStateMap     map[types.TaskIndex]*taskState
 	cancelTaskCtx    context.CancelFunc
 	cancelCleanupCtx context.CancelFunc
-}
-
-type taskExecutionState struct {
-	index            uint64
-	task             types.Task
-	taskDepth        uint64
-	taskVars         types.Variables
-	logger           *logger.LogScope
-	parentState      *taskExecutionState
-	isStarted        bool
-	isRunning        bool
-	isTimeout        bool
-	startTime        time.Time
-	stopTime         time.Time
-	updatedResult    bool
-	taskResult       types.TaskResult
-	taskError        error
-	resultNotifyChan chan bool
-	resultMutex      sync.RWMutex
 }
 
 func NewTaskScheduler(log logrus.FieldLogger, services types.TaskServices, variables types.Variables) *TaskScheduler {
@@ -53,151 +30,37 @@ func NewTaskScheduler(log logrus.FieldLogger, services types.TaskServices, varia
 		logger:       log,
 		rootVars:     variables,
 		taskCount:    1,
-		rootTasks:    make([]types.Task, 0),
-		allTasks:     make([]types.Task, 0),
-		taskStateMap: make(map[types.Task]*taskExecutionState),
+		rootTasks:    make([]types.TaskIndex, 0),
+		allTasks:     make([]types.TaskIndex, 0),
+		taskStateMap: make(map[types.TaskIndex]*taskState),
 		services:     services,
 	}
-}
-
-func (ts *TaskScheduler) GetTaskCount() int {
-	if ts == nil {
-		return 0
-	}
-
-	return len(ts.allTasks)
 }
 
 func (ts *TaskScheduler) GetServices() types.TaskServices {
 	return ts.services
 }
 
-func (ts *TaskScheduler) AddRootTask(options *types.TaskOptions) (types.Task, error) {
+func (ts *TaskScheduler) AddRootTask(options *types.TaskOptions) (types.TaskIndex, error) {
 	task, err := ts.newTask(options, nil, nil, false)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	ts.rootTasks = append(ts.rootTasks, task)
+	ts.rootTasks = append(ts.rootTasks, task.index)
 
-	return task, nil
+	return task.index, nil
 }
 
-func (ts *TaskScheduler) AddCleanupTask(options *types.TaskOptions) (types.Task, error) {
+func (ts *TaskScheduler) AddCleanupTask(options *types.TaskOptions) (types.TaskIndex, error) {
 	task, err := ts.newTask(options, nil, nil, true)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	ts.rootCleanupTasks = append(ts.rootCleanupTasks, task)
+	ts.rootCleanupTasks = append(ts.rootCleanupTasks, task.index)
 
-	return task, nil
-}
-
-func (ts *TaskScheduler) newTask(options *types.TaskOptions, parentState *taskExecutionState, variables types.Variables, isCleanupTask bool) (types.Task, error) {
-	// lookup task by name
-	var taskDescriptor *types.TaskDescriptor
-
-	for _, taskDesc := range tasks.AvailableTaskDescriptors {
-		if taskDesc.Name == options.Name {
-			taskDescriptor = taskDesc
-			break
-		}
-	}
-
-	if taskDescriptor == nil {
-		return nil, fmt.Errorf("unknown task name: %v", options.Name)
-	}
-
-	if variables == nil {
-		if parentState != nil {
-			variables = parentState.taskVars
-		} else {
-			variables = ts.rootVars
-		}
-	}
-
-	// create instance of task
-	var task types.Task
-
-	taskIdx := ts.taskCount
-	taskState := &taskExecutionState{
-		index:       taskIdx,
-		parentState: parentState,
-		taskVars:    variables,
-		logger: logger.NewLogger(&logger.ScopeOptions{
-			Parent:      ts.logger.WithField("task", taskDescriptor.Name).WithField("taskidx", taskIdx),
-			HistorySize: 1000,
-		}),
-	}
-
-	if parentState != nil {
-		taskState.parentState = parentState
-		taskState.taskDepth = parentState.taskDepth + 1
-	}
-
-	taskCtx := &types.TaskContext{
-		Scheduler: ts,
-		Index:     taskIdx,
-		Vars:      variables,
-		Logger:    taskState.logger,
-		NewTask: func(options *types.TaskOptions, variables types.Variables) (types.Task, error) {
-			return ts.newTask(options, taskState, variables, isCleanupTask)
-		},
-		SetResult: func(result types.TaskResult) {
-			ts.setTaskResult(task, result, true)
-		},
-	}
-
-	ts.taskCount++
-
-	var err error
-	task, err = taskDescriptor.NewTask(taskCtx, options)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed task '%v' initialization: %w", options.Name, err)
-	}
-
-	// create internal execution state
-	ts.taskStateMutex.Lock()
-	taskState.task = task
-	ts.taskStateMap[task] = taskState
-
-	if isCleanupTask {
-		ts.allCleanupTasks = append(ts.allCleanupTasks, task)
-	} else {
-		ts.allTasks = append(ts.allTasks, task)
-	}
-	ts.taskStateMutex.Unlock()
-
-	return task, nil
-}
-
-func (ts *TaskScheduler) setTaskResult(task types.Task, result types.TaskResult, setUpdated bool) {
-	ts.taskStateMutex.RLock()
-	taskState := ts.taskStateMap[task]
-	ts.taskStateMutex.RUnlock()
-
-	if taskState == nil {
-		return
-	}
-
-	taskState.resultMutex.Lock()
-	defer taskState.resultMutex.Unlock()
-
-	if setUpdated {
-		taskState.updatedResult = true
-	}
-
-	if taskState.taskResult == result {
-		return
-	}
-
-	taskState.taskResult = result
-	if taskState.resultNotifyChan != nil {
-		close(taskState.resultNotifyChan)
-		taskState.resultNotifyChan = nil
-	}
+	return task.index, nil
 }
 
 func (ts *TaskScheduler) RunTasks(ctx context.Context, timeout time.Duration) error {
@@ -230,136 +93,15 @@ func (ts *TaskScheduler) RunTasks(ctx context.Context, timeout time.Duration) er
 }
 
 func (ts *TaskScheduler) runCleanupTasks(ctx context.Context) {
-	for _, task := range ts.rootCleanupTasks {
+	for _, taskIndex := range ts.rootCleanupTasks {
 		if ctx.Err() != nil {
 			return
 		}
 
-		err := ts.ExecuteTask(ctx, task, ts.WatchTaskPass)
+		err := ts.ExecuteTask(ctx, taskIndex, ts.WatchTaskPass)
 		if err != nil {
-			task.Logger().Errorf("cleanup task failed: %v", err)
-		}
-	}
-}
-
-// ExecuteTask executes a task
-// this function blocks until the task is executed or the context cancelled
-func (ts *TaskScheduler) ExecuteTask(ctx context.Context, task types.Task, taskWatchFn func(ctx context.Context, cancelFn context.CancelFunc, task types.Task)) error {
-	// check if task has already been started/executed
-	ts.taskStateMutex.RLock()
-	taskState := ts.taskStateMap[task]
-	ts.taskStateMutex.RUnlock()
-
-	if taskState == nil {
-		return fmt.Errorf("task state not found")
-	}
-
-	if taskState.isStarted {
-		return fmt.Errorf("task has already been executed")
-	}
-
-	taskState.isStarted = true
-	taskState.startTime = time.Now()
-	taskState.isRunning = true
-
-	defer func() {
-		taskState.isRunning = false
-		taskState.stopTime = time.Now()
-	}()
-
-	// load task config
-	err := task.LoadConfig()
-	if err != nil {
-		task.Logger().Errorf("config validation failed: %v", err)
-		ts.setTaskResult(task, types.TaskResultFailure, false)
-
-		return fmt.Errorf("task %v config validation failed: %w", task.Name(), err)
-	}
-
-	// create cancelable task context
-	taskCtx, taskCancelFn := context.WithCancel(ctx)
-	taskTimeout := task.Timeout()
-
-	if taskTimeout > 0 {
-		go func() {
-			select {
-			case <-time.After(taskTimeout):
-				taskState.isTimeout = true
-
-				task.Logger().Warnf("task timed out")
-				taskCancelFn()
-			case <-taskCtx.Done():
-			}
-		}()
-	}
-
-	defer taskCancelFn()
-
-	defer func() {
-		if r := recover(); r != nil {
-			pErr, ok := r.(error)
-			if ok {
-				taskState.taskError = pErr
-			}
-
-			task.Logger().Errorf("task execution panic: %v, stack: %v", r, string(debug.Stack()))
-			ts.setTaskResult(task, types.TaskResultFailure, false)
-		}
-	}()
-
-	// run task watcher if supplied
-	if taskWatchFn != nil {
-		go taskWatchFn(taskCtx, taskCancelFn, task)
-	}
-
-	// execute task
-	task.Logger().Infof("starting task")
-	err = task.Execute(taskCtx)
-
-	if err != nil {
-		task.Logger().Errorf("task execution returned error: %v", err)
-
-		if taskState.taskError == nil {
-			taskState.taskError = err
-		}
-	}
-
-	// set task result
-	if !taskState.updatedResult || taskState.taskResult == types.TaskResultNone {
-		// set task result if not already done by task
-		if taskState.isTimeout || err != nil {
-			ts.setTaskResult(task, types.TaskResultFailure, false)
-		} else {
-			ts.setTaskResult(task, types.TaskResultSuccess, false)
-		}
-	}
-
-	if taskState.taskResult == types.TaskResultFailure {
-		task.Logger().Warnf("task failed with failure result: %v", taskState.taskError)
-		return fmt.Errorf("task failed: %w", taskState.taskError)
-	}
-
-	task.Logger().Infof("task completed")
-
-	return nil
-}
-
-func (ts *TaskScheduler) WatchTaskPass(ctx context.Context, cancelFn context.CancelFunc, task types.Task) {
-	// poll task result and cancel context when task result is passed or failed
-	for {
-		updateChan := ts.GetTaskResultUpdateChan(task, types.TaskResultNone)
-		if updateChan != nil {
-			select {
-			case <-ctx.Done():
-				return
-			case <-updateChan:
-			}
-		}
-
-		taskStatus := ts.GetTaskStatus(task)
-		if taskStatus.Result != types.TaskResultNone {
-			cancelFn()
-			return
+			taskState := ts.getTaskState(taskIndex)
+			taskState.logger.GetLogger().Errorf("cleanup task failed: %v", err)
 		}
 	}
 }
@@ -374,45 +116,68 @@ func (ts *TaskScheduler) CancelTasks(cancelCleanup bool) {
 	}
 }
 
-func (ts *TaskScheduler) GetAllTasks() []types.Task {
+func (ts *TaskScheduler) getTaskState(taskIndex types.TaskIndex) *taskState {
 	ts.taskStateMutex.RLock()
-	taskList := make([]types.Task, len(ts.allTasks))
+	defer ts.taskStateMutex.RUnlock()
+
+	return ts.taskStateMap[taskIndex]
+}
+
+func (ts *TaskScheduler) GetTaskState(taskIndex types.TaskIndex) types.TaskState {
+	return ts.getTaskState(taskIndex)
+}
+
+func (ts *TaskScheduler) GetAllTasks() []types.TaskIndex {
+	ts.taskStateMutex.RLock()
+	defer ts.taskStateMutex.RUnlock()
+
+	taskList := make([]types.TaskIndex, len(ts.allTasks))
 	copy(taskList, ts.allTasks)
 	ts.sortTaskList(taskList)
-	ts.taskStateMutex.RUnlock()
 
 	return taskList
 }
 
-func (ts *TaskScheduler) GetRootTasks() []types.Task {
+func (ts *TaskScheduler) GetTaskCount() int {
+	if ts == nil {
+		return 0
+	}
+
+	return len(ts.allTasks)
+}
+
+func (ts *TaskScheduler) GetRootTasks() []types.TaskIndex {
 	ts.taskStateMutex.RLock()
-	taskList := make([]types.Task, len(ts.rootTasks))
+	defer ts.taskStateMutex.RUnlock()
+
+	taskList := make([]types.TaskIndex, len(ts.rootTasks))
 	copy(taskList, ts.rootTasks)
-	ts.taskStateMutex.RUnlock()
 
 	return taskList
 }
 
-func (ts *TaskScheduler) GetAllCleanupTasks() []types.Task {
+func (ts *TaskScheduler) GetAllCleanupTasks() []types.TaskIndex {
 	ts.taskStateMutex.RLock()
-	taskList := make([]types.Task, len(ts.allCleanupTasks))
+	defer ts.taskStateMutex.RUnlock()
+
+	taskList := make([]types.TaskIndex, len(ts.allCleanupTasks))
 	copy(taskList, ts.allCleanupTasks)
 	ts.sortTaskList(taskList)
-	ts.taskStateMutex.RUnlock()
 
 	return taskList
 }
 
-func (ts *TaskScheduler) GetRootCleanupTasks() []types.Task {
+func (ts *TaskScheduler) GetRootCleanupTasks() []types.TaskIndex {
 	ts.taskStateMutex.RLock()
-	taskList := make([]types.Task, len(ts.rootCleanupTasks))
+	defer ts.taskStateMutex.RUnlock()
+
+	taskList := make([]types.TaskIndex, len(ts.rootCleanupTasks))
 	copy(taskList, ts.rootCleanupTasks)
-	ts.taskStateMutex.RUnlock()
 
 	return taskList
 }
 
-func (ts *TaskScheduler) sortTaskList(taskList []types.Task) {
+func (ts *TaskScheduler) sortTaskList(taskList []types.TaskIndex) {
 	sort.Slice(taskList, func(a, b int) bool {
 		taskStateA := ts.taskStateMap[taskList[a]]
 		taskStateB := ts.taskStateMap[taskList[b]]
@@ -441,54 +206,4 @@ func (ts *TaskScheduler) sortTaskList(taskList []types.Task) {
 			}
 		}
 	})
-}
-
-func (ts *TaskScheduler) GetTaskStatus(task types.Task) *types.TaskStatus {
-	ts.taskStateMutex.RLock()
-	taskState := ts.taskStateMap[task]
-	ts.taskStateMutex.RUnlock()
-
-	if taskState == nil {
-		return nil
-	}
-
-	taskStatus := &types.TaskStatus{
-		Index:       taskState.index,
-		ParentIndex: 0,
-		IsStarted:   taskState.isStarted,
-		IsRunning:   taskState.isRunning,
-		StartTime:   taskState.startTime,
-		StopTime:    taskState.stopTime,
-		Result:      taskState.taskResult,
-		Error:       taskState.taskError,
-		Logger:      taskState.logger,
-	}
-	if taskState.parentState != nil {
-		taskStatus.ParentIndex = taskState.parentState.index
-	}
-
-	return taskStatus
-}
-
-func (ts *TaskScheduler) GetTaskResultUpdateChan(task types.Task, oldResult types.TaskResult) <-chan bool {
-	ts.taskStateMutex.RLock()
-	taskState := ts.taskStateMap[task]
-	ts.taskStateMutex.RUnlock()
-
-	if taskState == nil {
-		return nil
-	}
-
-	taskState.resultMutex.RLock()
-	defer taskState.resultMutex.RUnlock()
-
-	if taskState.taskResult != oldResult {
-		return nil
-	}
-
-	if taskState.resultNotifyChan == nil {
-		taskState.resultNotifyChan = make(chan bool)
-	}
-
-	return taskState.resultNotifyChan
 }

--- a/pkg/coordinator/scheduler/scheduler.go
+++ b/pkg/coordinator/scheduler/scheduler.go
@@ -42,7 +42,7 @@ func (ts *TaskScheduler) GetServices() types.TaskServices {
 }
 
 func (ts *TaskScheduler) AddRootTask(options *types.TaskOptions) (types.TaskIndex, error) {
-	task, err := ts.newTask(options, nil, nil, false)
+	task, err := ts.newTaskState(options, nil, nil, false)
 	if err != nil {
 		return 0, err
 	}
@@ -53,7 +53,7 @@ func (ts *TaskScheduler) AddRootTask(options *types.TaskOptions) (types.TaskInde
 }
 
 func (ts *TaskScheduler) AddCleanupTask(options *types.TaskOptions) (types.TaskIndex, error) {
-	task, err := ts.newTask(options, nil, nil, true)
+	task, err := ts.newTaskState(options, nil, nil, true)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/coordinator/scheduler/task_execution.go
+++ b/pkg/coordinator/scheduler/task_execution.go
@@ -27,10 +27,13 @@ func (ts *TaskScheduler) ExecuteTask(ctx context.Context, taskIndex types.TaskIn
 	taskState.isStarted = true
 	taskState.startTime = time.Now()
 	taskState.isRunning = true
+	taskState.taskStatusVars.SetVar("started", true)
+	taskState.taskStatusVars.SetVar("running", true)
 
 	defer func() {
 		taskState.isRunning = false
 		taskState.stopTime = time.Now()
+		taskState.taskStatusVars.SetVar("running", false)
 	}()
 
 	// create task control context
@@ -83,6 +86,7 @@ func (ts *TaskScheduler) ExecuteTask(ctx context.Context, taskIndex types.TaskIn
 			select {
 			case <-time.After(taskTimeout):
 				taskState.isTimeout = true
+				taskState.taskStatusVars.SetVar("timeout", true)
 
 				taskLogger.Warnf("task timed out")
 				taskCancelFn()

--- a/pkg/coordinator/scheduler/task_execution.go
+++ b/pkg/coordinator/scheduler/task_execution.go
@@ -1,0 +1,160 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+)
+
+// ExecuteTask executes a task
+// this function blocks until the task is executed or the context cancelled
+func (ts *TaskScheduler) ExecuteTask(ctx context.Context, taskIndex types.TaskIndex, taskWatchFn func(ctx context.Context, cancelFn context.CancelFunc, taskIndex types.TaskIndex)) error {
+	taskState := ts.getTaskState(taskIndex)
+	if taskState == nil {
+		return fmt.Errorf("task not found")
+	}
+
+	taskLogger := taskState.logger.GetLogger()
+
+	// check if task has already been started/executed
+	if taskState.isStarted {
+		return fmt.Errorf("task has already been executed")
+	}
+
+	taskState.isStarted = true
+	taskState.startTime = time.Now()
+	taskState.isRunning = true
+
+	defer func() {
+		taskState.isRunning = false
+		taskState.stopTime = time.Now()
+	}()
+
+	// initialize task instance
+	taskCtx := &types.TaskContext{
+		Scheduler: ts,
+		Index:     taskState.index,
+		Vars:      taskState.taskVars,
+		Logger:    taskState.logger,
+		NewTask: func(options *types.TaskOptions, variables types.Variables) (types.TaskIndex, error) {
+			task, err := ts.newTask(options, taskState, variables, taskState.isCleanup)
+			if err != nil {
+				return 0, err
+			}
+
+			return task.index, nil
+		},
+		SetResult: func(result types.TaskResult) {
+			taskState.setTaskResult(result, true)
+		},
+	}
+
+	// create task instance
+	task, err := taskState.descriptor.NewTask(taskCtx, taskState.options)
+	if err != nil {
+		return fmt.Errorf("failed task '%v' initialization: %w", taskState.options.Name, err)
+	}
+
+	// load task config
+	err = task.LoadConfig()
+	if err != nil {
+		taskLogger.Errorf("config validation failed: %v", err)
+		taskState.setTaskResult(types.TaskResultFailure, false)
+
+		return fmt.Errorf("task %v config validation failed: %w", taskState.Name(), err)
+	}
+
+	taskState.taskConfig = task.Config()
+
+	// create cancelable task context
+	taskContext, taskCancelFn := context.WithCancel(ctx)
+	taskTimeout := task.Timeout()
+
+	if taskTimeout > 0 {
+		go func() {
+			select {
+			case <-time.After(taskTimeout):
+				taskState.isTimeout = true
+
+				taskLogger.Warnf("task timed out")
+				taskCancelFn()
+			case <-taskContext.Done():
+			}
+		}()
+	}
+
+	defer taskCancelFn()
+
+	defer func() {
+		if r := recover(); r != nil {
+			pErr, ok := r.(error)
+			if ok {
+				taskState.taskError = pErr
+			}
+
+			taskLogger.Errorf("task execution panic: %v, stack: %v", r, string(debug.Stack()))
+			taskState.setTaskResult(types.TaskResultFailure, false)
+		}
+	}()
+
+	// run task watcher if supplied
+	if taskWatchFn != nil {
+		go taskWatchFn(taskContext, taskCancelFn, taskState.index)
+	}
+
+	// execute task
+	taskLogger.Infof("starting task")
+
+	err = task.Execute(taskContext)
+	if err != nil {
+		taskLogger.Errorf("task execution returned error: %v", err)
+
+		if taskState.taskError == nil {
+			taskState.taskError = err
+		}
+	}
+
+	// set task result
+	if !taskState.updatedResult || taskState.taskResult == types.TaskResultNone {
+		// set task result if not already done by task
+		if taskState.isTimeout || err != nil {
+			taskState.setTaskResult(types.TaskResultFailure, false)
+		} else {
+			taskState.setTaskResult(types.TaskResultSuccess, false)
+		}
+	}
+
+	if taskState.taskResult == types.TaskResultFailure {
+		taskLogger.Warnf("task failed with failure result: %v", taskState.taskError)
+		return fmt.Errorf("task failed: %w", taskState.taskError)
+	}
+
+	taskLogger.Infof("task completed")
+
+	return nil
+}
+
+func (ts *TaskScheduler) WatchTaskPass(ctx context.Context, cancelFn context.CancelFunc, taskIndex types.TaskIndex) {
+	taskState := ts.GetTaskState(taskIndex)
+
+	// poll task result and cancel context when task result is passed or failed
+	for {
+		updateChan := taskState.GetTaskResultUpdateChan(types.TaskResultNone)
+		if updateChan != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case <-updateChan:
+			}
+		}
+
+		taskStatus := taskState.GetTaskStatus()
+		if taskStatus.Result != types.TaskResultNone {
+			cancelFn()
+			return
+		}
+	}
+}

--- a/pkg/coordinator/scheduler/task_execution.go
+++ b/pkg/coordinator/scheduler/task_execution.go
@@ -41,6 +41,7 @@ func (ts *TaskScheduler) ExecuteTask(ctx context.Context, taskIndex types.TaskIn
 		Scheduler: ts,
 		Index:     taskState.index,
 		Vars:      taskState.taskVars,
+		Outputs:   taskState.taskOutputs,
 		Logger:    taskState.logger,
 		NewTask: func(options *types.TaskOptions, variables types.Variables) (types.TaskIndex, error) {
 			task, err := ts.newTaskState(options, taskState, variables, taskState.isCleanup)

--- a/pkg/coordinator/scheduler/task_state.go
+++ b/pkg/coordinator/scheduler/task_state.go
@@ -83,7 +83,7 @@ func (ts *TaskScheduler) newTaskState(options *types.TaskOptions, parentState *t
 		taskState.taskDepth = parentState.taskDepth + 1
 	}
 
-	taskState.taskStatusVars.NewSubScope("outputs")
+	taskState.taskStatusVars.SetSubScope("outputs", taskState.taskOutputs)
 
 	if options.ID != "" {
 		tasksScope := variables.GetSubScope("tasks")

--- a/pkg/coordinator/scheduler/task_state.go
+++ b/pkg/coordinator/scheduler/task_state.go
@@ -36,7 +36,7 @@ type taskState struct {
 	resultMutex      sync.RWMutex
 }
 
-func (ts *TaskScheduler) newTask(options *types.TaskOptions, parentState *taskState, variables types.Variables, isCleanupTask bool) (*taskState, error) {
+func (ts *TaskScheduler) newTaskState(options *types.TaskOptions, parentState *taskState, variables types.Variables, isCleanupTask bool) (*taskState, error) {
 	if variables == nil {
 		if parentState != nil {
 			variables = parentState.taskVars

--- a/pkg/coordinator/scheduler/task_state.go
+++ b/pkg/coordinator/scheduler/task_state.go
@@ -150,6 +150,10 @@ func (ts *taskState) GetTaskStatusVars() types.Variables {
 	return ts.taskStatusVars
 }
 
+func (ts *taskState) GetTaskVars() types.Variables {
+	return ts.taskVars
+}
+
 func (ts *taskState) GetTaskResultUpdateChan(oldResult types.TaskResult) <-chan bool {
 	ts.resultMutex.RLock()
 	defer ts.resultMutex.RUnlock()

--- a/pkg/coordinator/scheduler/task_state.go
+++ b/pkg/coordinator/scheduler/task_state.go
@@ -1,0 +1,188 @@
+package scheduler
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethpandaops/assertoor/pkg/coordinator/logger"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/tasks"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+)
+
+type taskState struct {
+	index       types.TaskIndex
+	options     *types.TaskOptions
+	descriptor  *types.TaskDescriptor
+	task        types.Task
+	taskDepth   uint64
+	taskVars    types.Variables
+	logger      *logger.LogScope
+	parentState *taskState
+
+	isCleanup bool
+	isStarted bool
+	isRunning bool
+	isTimeout bool
+	startTime time.Time
+	stopTime  time.Time
+
+	taskConfig interface{}
+
+	updatedResult    bool
+	taskResult       types.TaskResult
+	taskError        error
+	resultNotifyChan chan bool
+	resultMutex      sync.RWMutex
+}
+
+func (ts *TaskScheduler) newTask(options *types.TaskOptions, parentState *taskState, variables types.Variables, isCleanupTask bool) (*taskState, error) {
+	if variables == nil {
+		if parentState != nil {
+			variables = parentState.taskVars
+		} else {
+			variables = ts.rootVars
+		}
+	}
+
+	// lookup task descriptor by name
+	var taskDescriptor *types.TaskDescriptor
+
+	for _, taskDesc := range tasks.AvailableTaskDescriptors {
+		if taskDesc.Name == options.Name {
+			taskDescriptor = taskDesc
+			break
+		}
+	}
+
+	if taskDescriptor == nil {
+		return nil, fmt.Errorf("unknown task name: %v", options.Name)
+	}
+
+	// create task state
+	taskIdx := ts.taskCount
+	taskState := &taskState{
+		index:       taskIdx,
+		options:     options,
+		descriptor:  taskDescriptor,
+		parentState: parentState,
+		taskVars:    variables,
+		logger: logger.NewLogger(&logger.ScopeOptions{
+			Parent:      ts.logger.WithField("task", options.Name).WithField("taskidx", taskIdx),
+			HistorySize: 1000,
+		}),
+	}
+
+	if parentState != nil {
+		taskState.parentState = parentState
+		taskState.taskDepth = parentState.taskDepth + 1
+	}
+
+	ts.taskCount++
+
+	// create internal execution state
+	ts.taskStateMutex.Lock()
+	ts.taskStateMap[taskIdx] = taskState
+
+	if isCleanupTask {
+		ts.allCleanupTasks = append(ts.allCleanupTasks, taskIdx)
+	} else {
+		ts.allTasks = append(ts.allTasks, taskIdx)
+	}
+	ts.taskStateMutex.Unlock()
+
+	return taskState, nil
+}
+
+func (ts *taskState) setTaskResult(result types.TaskResult, setUpdated bool) {
+	ts.resultMutex.Lock()
+	defer ts.resultMutex.Unlock()
+
+	if setUpdated {
+		ts.updatedResult = true
+	}
+
+	if ts.taskResult == result {
+		return
+	}
+
+	ts.taskResult = result
+	if ts.resultNotifyChan != nil {
+		close(ts.resultNotifyChan)
+		ts.resultNotifyChan = nil
+	}
+}
+
+func (ts *taskState) GetTaskStatus() *types.TaskStatus {
+	taskStatus := &types.TaskStatus{
+		Index:       ts.index,
+		ParentIndex: 0,
+		IsStarted:   ts.isStarted,
+		IsRunning:   ts.isRunning,
+		StartTime:   ts.startTime,
+		StopTime:    ts.stopTime,
+		Result:      ts.taskResult,
+		Error:       ts.taskError,
+		Logger:      ts.logger,
+	}
+	if ts.parentState != nil {
+		taskStatus.ParentIndex = ts.parentState.index
+	}
+
+	return taskStatus
+}
+
+func (ts *taskState) GetTaskResultUpdateChan(oldResult types.TaskResult) <-chan bool {
+	ts.resultMutex.RLock()
+	defer ts.resultMutex.RUnlock()
+
+	if ts.taskResult != oldResult {
+		return nil
+	}
+
+	if ts.resultNotifyChan == nil {
+		ts.resultNotifyChan = make(chan bool)
+	}
+
+	return ts.resultNotifyChan
+}
+
+func (ts *taskState) Index() types.TaskIndex {
+	return ts.index
+}
+
+func (ts *taskState) ParentIndex() types.TaskIndex {
+	if ts.parentState != nil {
+		return ts.parentState.index
+	}
+
+	return 0
+}
+
+func (ts *taskState) Name() string {
+	return ts.options.Name
+}
+
+func (ts *taskState) Title() string {
+	return ts.taskVars.ResolvePlaceholders(ts.options.Title)
+}
+
+func (ts *taskState) Description() string {
+	return ts.descriptor.Description
+}
+
+func (ts *taskState) Config() interface{} {
+	if ts.task != nil {
+		return ts.task.Config()
+	}
+
+	return ts.taskConfig
+}
+
+func (ts *taskState) Timeout() time.Duration {
+	if ts.task != nil {
+		return ts.task.Timeout()
+	}
+
+	return ts.options.Timeout.Duration
+}

--- a/pkg/coordinator/tasks/check_clients_are_healthy/task.go
+++ b/pkg/coordinator/tasks/check_clients_are_healthy/task.go
@@ -37,24 +37,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_clients_are_healthy/task.go
+++ b/pkg/coordinator/tasks/check_clients_are_healthy/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/consensus"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/execution"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,12 @@ type Task struct {
 	options *types.TaskOptions
 	config  Config
 	logger  logrus.FieldLogger
+}
+
+type ClientInfo struct {
+	Name     string `json:"name"`
+	ClRPCURL string `json:"clRpcUrl"`
+	ElRPCURL string `json:"elRpcUrl"`
 }
 
 func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, error) {
@@ -88,7 +95,9 @@ func (t *Task) processCheck() {
 	expectedResult := !t.config.ExpectUnhealthy
 	passResultCount := 0
 	totalClientCount := 0
-	failedClients := []string{}
+	goodClients := []*ClientInfo{}
+	failedClients := []*ClientInfo{}
+	failedClientNames := []string{}
 
 	for _, client := range t.ctx.Scheduler.GetServices().ClientPool().GetClientsByNamePatterns(t.config.ClientPattern, "") {
 		totalClientCount++
@@ -96,6 +105,8 @@ func (t *Task) processCheck() {
 		checkResult := t.processClientCheck(client)
 		if checkResult == expectedResult {
 			passResultCount++
+
+			goodClients = append(goodClients, t.getClientInfo(client))
 
 			if t.config.ExecutionRPCResultVar != "" && passResultCount == 1 && client.ExecutionClient != nil {
 				t.ctx.Vars.SetVar(t.config.ExecutionRPCResultVar, client.ExecutionClient.GetEndpointConfig().URL)
@@ -105,7 +116,8 @@ func (t *Task) processCheck() {
 				t.ctx.Vars.SetVar(t.config.ConsensusRPCResultVar, client.ConsensusClient.GetEndpointConfig().URL)
 			}
 		} else {
-			failedClients = append(failedClients, client.Config.Name)
+			failedClients = append(failedClients, t.getClientInfo(client))
+			failedClientNames = append(failedClientNames, client.Config.Name)
 		}
 	}
 
@@ -116,7 +128,23 @@ func (t *Task) processCheck() {
 
 	resultPass := passResultCount >= requiredPassCount
 
-	t.logger.Infof("Check result: %v, Failed Clients: %v", resultPass, failedClients)
+	if goodClientsData, err := vars.GeneralizeData(goodClients); err == nil {
+		t.ctx.Outputs.SetVar("goodClients", goodClientsData)
+	} else {
+		t.logger.Warnf("Failed setting `goodClients` output: %v", err)
+	}
+
+	if failedClientsData, err := vars.GeneralizeData(failedClients); err == nil {
+		t.ctx.Outputs.SetVar("failedClients", failedClientsData)
+	} else {
+		t.logger.Warnf("Failed setting `failedClients` output: %v", err)
+	}
+
+	t.ctx.Outputs.SetVar("totalCount", totalClientCount)
+	t.ctx.Outputs.SetVar("failedCount", totalClientCount-passResultCount)
+	t.ctx.Outputs.SetVar("goodCount", passResultCount)
+
+	t.logger.Infof("Check result: %v, Failed Clients: %v", resultPass, failedClientNames)
 
 	switch {
 	case t.config.MaxUnhealthyCount > -1 && len(failedClients) > t.config.MaxUnhealthyCount:
@@ -134,6 +162,22 @@ func (t *Task) processCheck() {
 			t.ctx.SetResult(types.TaskResultNone)
 		}
 	}
+}
+
+func (t *Task) getClientInfo(client *clients.PoolClient) *ClientInfo {
+	clientInfo := &ClientInfo{
+		Name: client.Config.Name,
+	}
+
+	if client.ExecutionClient != nil {
+		clientInfo.ElRPCURL = client.ExecutionClient.GetEndpointConfig().URL
+	}
+
+	if client.ConsensusClient != nil {
+		clientInfo.ClRPCURL = client.ConsensusClient.GetEndpointConfig().URL
+	}
+
+	return clientInfo
 }
 
 func (t *Task) processClientCheck(client *clients.PoolClient) bool {

--- a/pkg/coordinator/tasks/check_consensus_attestation_stats/task.go
+++ b/pkg/coordinator/tasks/check_consensus_attestation_stats/task.go
@@ -50,24 +50,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_attestation_stats/task.go
+++ b/pkg/coordinator/tasks/check_consensus_attestation_stats/task.go
@@ -255,6 +255,16 @@ func (t *Task) checkEpochVotes(epoch uint64, epochVote *epochVotes) bool {
 	t.logger.Infof("epoch %v head votes: %v (%.2f%%)", epoch, epochVote.currentEpoch.headVoteCount+epochVote.nextEpoch.headVoteCount, headPercent)
 	t.logger.Infof("epoch %v total votes: %v (%.2f%%)", epoch, epochVote.currentEpoch.totalVoteCount+epochVote.nextEpoch.totalVoteCount, totalPercent)
 
+	t.ctx.Outputs.SetVar("lastCheckedEpoch", epoch)
+	t.ctx.Outputs.SetVar("validatorCount", epochVote.attesterDuties.validatorCount)
+	t.ctx.Outputs.SetVar("validatorBalance", epochVote.attesterDuties.validatorBalance)
+	t.ctx.Outputs.SetVar("targetVotes", epochVote.currentEpoch.targetVoteCount+epochVote.nextEpoch.targetVoteCount)
+	t.ctx.Outputs.SetVar("targetVotesPercent", targetPercent)
+	t.ctx.Outputs.SetVar("headVotes", epochVote.currentEpoch.headVoteCount+epochVote.nextEpoch.headVoteCount)
+	t.ctx.Outputs.SetVar("headVotesPercent", headPercent)
+	t.ctx.Outputs.SetVar("totalVotes", epochVote.currentEpoch.totalVoteCount+epochVote.nextEpoch.totalVoteCount)
+	t.ctx.Outputs.SetVar("totalVotesPercent", totalPercent)
+
 	if t.config.MinTargetPercent > 0 && targetPercent < float64(t.config.MinTargetPercent) {
 		t.logger.Debugf("check failed for epoch %v: target vote percent (want: >= %v, have: %.2f%)", epoch, t.config.MinTargetPercent, targetPercent)
 		return false

--- a/pkg/coordinator/tasks/check_consensus_block_proposals/task.go
+++ b/pkg/coordinator/tasks/check_consensus_block_proposals/task.go
@@ -40,24 +40,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_block_proposals/task.go
+++ b/pkg/coordinator/tasks/check_consensus_block_proposals/task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/consensus"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/juliangruber/go-intersect"
 	"github.com/sirupsen/logrus"
 )
@@ -81,12 +82,14 @@ func (t *Task) Execute(ctx context.Context) error {
 	defer blockSubscription.Unsubscribe()
 
 	totalMatches := 0
+	matchingBlocks := []*consensus.Block{}
 
 	for {
 		select {
 		case block := <-blockSubscription.Channel():
 			matches := t.checkBlock(ctx, block)
 			if matches {
+				matchingBlocks = append(matchingBlocks, block)
 				t.logger.Infof("matching block %v [0x%x]", block.Slot, block.Root)
 
 				totalMatches++
@@ -94,7 +97,9 @@ func (t *Task) Execute(ctx context.Context) error {
 
 			if t.config.BlockCount > 0 {
 				if totalMatches >= t.config.BlockCount {
+					t.setMatchingBlocksOutput(matchingBlocks)
 					t.ctx.SetResult(types.TaskResultSuccess)
+
 					return nil
 				}
 			} else {
@@ -108,6 +113,37 @@ func (t *Task) Execute(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+func (t *Task) setMatchingBlocksOutput(blocks []*consensus.Block) {
+	blockRoots := []string{}
+	blockHeaders := []any{}
+	blockBodies := []any{}
+
+	for _, block := range blocks {
+		blockRoots = append(blockRoots, block.Root.String())
+
+		var blockHeader, blockBody any
+
+		if header, err := vars.GeneralizeData(block.GetHeader()); err == nil {
+			blockHeader = header
+		} else {
+			t.logger.Warnf("Failed encoding block #%v header for matchingBlockHeaders output: %v", block.Slot, err)
+		}
+
+		if body, err := vars.GeneralizeData(consensus.GetBlockBody(block.GetBlock())); err == nil {
+			blockBody = body
+		} else {
+			t.logger.Warnf("Failed encoding block #%v header for matchingBlockHeaders output: %v", block.Slot, err)
+		}
+
+		blockHeaders = append(blockHeaders, blockHeader)
+		blockBodies = append(blockBodies, blockBody)
+	}
+
+	t.ctx.Outputs.SetVar("matchingBlockRoots", blockRoots)
+	t.ctx.Outputs.SetVar("matchingBlockHeaders", blockHeaders)
+	t.ctx.Outputs.SetVar("matchingBlockBodies", blockBodies)
 }
 
 //nolint:gocyclo // ignore

--- a/pkg/coordinator/tasks/check_consensus_finality/task.go
+++ b/pkg/coordinator/tasks/check_consensus_finality/task.go
@@ -36,24 +36,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_finality/task.go
+++ b/pkg/coordinator/tasks/check_consensus_finality/task.go
@@ -111,8 +111,12 @@ func (t *Task) runFinalityCheck() bool {
 		return false
 	}
 
-	finalizedEpoch, _ := consensusPool.GetBlockCache().GetFinalizedCheckpoint()
+	finalizedEpoch, finalizedRoot := consensusPool.GetBlockCache().GetFinalizedCheckpoint()
 	unfinalizedEpochs := currentEpoch.Number() - uint64(finalizedEpoch)
+
+	t.ctx.Outputs.SetVar("finalizedEpoch", finalizedEpoch)
+	t.ctx.Outputs.SetVar("finalizedRoot", finalizedRoot.String())
+	t.ctx.Outputs.SetVar("unfinalizedEpochs", unfinalizedEpochs)
 
 	if t.config.MinUnfinalizedEpochs > 0 && unfinalizedEpochs < t.config.MinUnfinalizedEpochs {
 		t.logger.Infof("check failed: minUnfinalizedEpochs (have: %v, want >= %v)", unfinalizedEpochs, t.config.MinUnfinalizedEpochs)

--- a/pkg/coordinator/tasks/check_consensus_forks/task.go
+++ b/pkg/coordinator/tasks/check_consensus_forks/task.go
@@ -35,24 +35,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_proposer_duty/task.go
+++ b/pkg/coordinator/tasks/check_consensus_proposer_duty/task.go
@@ -38,24 +38,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_reorgs/task.go
+++ b/pkg/coordinator/tasks/check_consensus_reorgs/task.go
@@ -39,24 +39,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_slot_range/task.go
+++ b/pkg/coordinator/tasks/check_consensus_slot_range/task.go
@@ -36,24 +36,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_slot_range/task.go
+++ b/pkg/coordinator/tasks/check_consensus_slot_range/task.go
@@ -109,6 +109,10 @@ func (t *Task) runRangeCheck() (checkResult, isLower bool) {
 		return false, true
 	}
 
+	t.ctx.Outputs.SetVar("genesisTime", consensusPool.GetBlockCache().GetGenesis().GenesisTime.Unix())
+	t.ctx.Outputs.SetVar("currentSlot", currentSlot.Number())
+	t.ctx.Outputs.SetVar("currentEpoch", currentEpoch.Number())
+
 	if currentSlot.Number() < t.config.MinSlotNumber {
 		return false, true
 	}

--- a/pkg/coordinator/tasks/check_consensus_sync_status/task.go
+++ b/pkg/coordinator/tasks/check_consensus_sync_status/task.go
@@ -38,24 +38,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_consensus_validator_status/task.go
+++ b/pkg/coordinator/tasks/check_consensus_validator_status/task.go
@@ -39,24 +39,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/check_execution_sync_status/task.go
+++ b/pkg/coordinator/tasks/check_execution_sync_status/task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/execution/rpc"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,13 @@ type Task struct {
 	config      Config
 	logger      logrus.FieldLogger
 	firstHeight map[uint16]uint64
+}
+
+type ClientInfo struct {
+	Name          string `json:"name"`
+	Synchronizing bool   `json:"synchronizing"`
+	SyncHead      uint64 `json:"syncHead"`
+	SyncDistance  uint64 `json:"syncDistance"`
 }
 
 func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, error) {
@@ -87,7 +95,9 @@ func (t *Task) Execute(ctx context.Context) error {
 
 func (t *Task) processCheck(ctx context.Context) {
 	allResultsPass := true
-	failedClients := []string{}
+	goodClients := []*ClientInfo{}
+	failedClients := []*ClientInfo{}
+	failedClientNames := []string{}
 
 	for _, client := range t.ctx.Scheduler.GetServices().ClientPool().GetClientsByNamePatterns(t.config.ClientPattern, "") {
 		var checkResult bool
@@ -110,11 +120,26 @@ func (t *Task) processCheck(ctx context.Context) {
 		if !checkResult {
 			allResultsPass = false
 
-			failedClients = append(failedClients, client.Config.Name)
+			failedClients = append(failedClients, t.getClientInfo(client, syncStatus))
+			failedClientNames = append(failedClientNames, client.Config.Name)
+		} else {
+			goodClients = append(goodClients, t.getClientInfo(client, syncStatus))
 		}
 	}
 
-	t.logger.Infof("Check result: %v, Failed Clients: %v", allResultsPass, failedClients)
+	t.logger.Infof("Check result: %v, Failed Clients: %v", allResultsPass, failedClientNames)
+
+	if goodClientsData, err := vars.GeneralizeData(goodClients); err == nil {
+		t.ctx.Outputs.SetVar("goodClients", goodClientsData)
+	} else {
+		t.logger.Warnf("Failed setting `goodClients` output: %v", err)
+	}
+
+	if failedClientsData, err := vars.GeneralizeData(failedClients); err == nil {
+		t.ctx.Outputs.SetVar("failedClients", failedClientsData)
+	} else {
+		t.logger.Warnf("Failed setting `failedClients` output: %v", err)
+	}
 
 	if allResultsPass {
 		t.ctx.SetResult(types.TaskResultSuccess)
@@ -158,4 +183,15 @@ func (t *Task) processClientCheck(client *clients.PoolClient, syncStatus *rpc.Sy
 	}
 
 	return true
+}
+
+func (t *Task) getClientInfo(client *clients.PoolClient, syncStatus *rpc.SyncStatus) *ClientInfo {
+	clientInfo := &ClientInfo{
+		Name:          client.Config.Name,
+		Synchronizing: syncStatus.IsSyncing,
+		SyncHead:      syncStatus.CurrentBlock,
+		SyncDistance:  syncStatus.HighestBlock - syncStatus.CurrentBlock,
+	}
+
+	return clientInfo
 }

--- a/pkg/coordinator/tasks/check_execution_sync_status/task.go
+++ b/pkg/coordinator/tasks/check_execution_sync_status/task.go
@@ -38,24 +38,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_blob_transactions/task.go
+++ b/pkg/coordinator/tasks/generate_blob_transactions/task.go
@@ -50,24 +50,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_bls_changes/task.go
+++ b/pkg/coordinator/tasks/generate_bls_changes/task.go
@@ -50,24 +50,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_child_wallet/task.go
+++ b/pkg/coordinator/tasks/generate_child_wallet/task.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/wallet"
 	"github.com/sirupsen/logrus"
 )
@@ -108,6 +109,13 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	childWallet := walletPool.GetNextChildWallet()
 	t.logger.Infof("child wallet: %v [nonce: %v]  %v ETH", childWallet.GetAddress().Hex(), childWallet.GetNonce(), childWallet.GetReadableBalance(18, 0, 4, false, false))
+
+	walletSummary := childWallet.GetSummary()
+	if walletSummaryData, err := vars.GeneralizeData(walletSummary); err == nil {
+		t.ctx.Outputs.SetVar("childWallet", walletSummaryData)
+	} else {
+		t.logger.Warnf("Failed setting `childWallet` output: %v", err)
+	}
 
 	if t.config.WalletAddressResultVar != "" {
 		t.ctx.Vars.SetVar(t.config.WalletAddressResultVar, childWallet.GetAddress().Hex())

--- a/pkg/coordinator/tasks/generate_child_wallet/task.go
+++ b/pkg/coordinator/tasks/generate_child_wallet/task.go
@@ -38,24 +38,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskDescriptor.Name
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_deposits/task.go
+++ b/pkg/coordinator/tasks/generate_deposits/task.go
@@ -60,24 +60,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_eoa_transactions/task.go
+++ b/pkg/coordinator/tasks/generate_eoa_transactions/task.go
@@ -50,24 +50,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_exits/task.go
+++ b/pkg/coordinator/tasks/generate_exits/task.go
@@ -48,24 +48,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_random_mnemonic/task.go
+++ b/pkg/coordinator/tasks/generate_random_mnemonic/task.go
@@ -35,24 +35,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskDescriptor.Name
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_random_mnemonic/task.go
+++ b/pkg/coordinator/tasks/generate_random_mnemonic/task.go
@@ -86,5 +86,7 @@ func (t *Task) Execute(_ context.Context) error {
 		t.ctx.Vars.SetVar(t.config.MnemonicResultVar, mnemonic)
 	}
 
+	t.ctx.Outputs.SetVar("mnemonic", mnemonic)
+
 	return nil
 }

--- a/pkg/coordinator/tasks/generate_slashings/task.go
+++ b/pkg/coordinator/tasks/generate_slashings/task.go
@@ -50,24 +50,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/generate_transaction/task.go
+++ b/pkg/coordinator/tasks/generate_transaction/task.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/execution"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/wallet"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/wallet/blobtx"
 	"github.com/holiman/uint256"
@@ -167,6 +167,8 @@ func (t *Task) Execute(ctx context.Context) error {
 		t.ctx.Vars.SetVar(t.config.TransactionHashResultVar, tx.Hash().Hex())
 	}
 
+	t.ctx.Outputs.SetVar("transactionHash", tx.Hash().Hex())
+
 	if t.config.AwaitReceipt {
 		receipt, err := t.wallet.AwaitTransaction(ctx, tx)
 		if err != nil {
@@ -192,20 +194,16 @@ func (t *Task) Execute(ctx context.Context) error {
 			t.ctx.Vars.SetVar(t.config.ContractAddressResultVar, receipt.ContractAddress.Hex())
 		}
 
-		if t.config.TransactionReceiptResultVar != "" {
-			receiptJSON, err := json.Marshal(receipt)
-			if err == nil {
-				receiptMap := map[string]interface{}{}
-				err = json.Unmarshal(receiptJSON, &receiptMap)
+		t.ctx.Outputs.SetVar("contractAddress", receipt.ContractAddress.Hex())
 
-				if err == nil {
-					t.ctx.Vars.SetVar(t.config.TransactionReceiptResultVar, receiptMap)
-				} else {
-					t.logger.Errorf("could not unmarshal transaction receipt for result var: %v", err)
-				}
-			} else {
-				t.logger.Errorf("could not marshal transaction receipt for result var: %v", err)
+		if receiptData, err := vars.GeneralizeData(receipt); err == nil {
+			t.ctx.Outputs.SetVar("receipt", receiptData)
+
+			if t.config.TransactionReceiptResultVar != "" {
+				t.ctx.Vars.SetVar(t.config.TransactionReceiptResultVar, receiptData)
 			}
+		} else {
+			t.logger.Warnf("Failed setting `receipt` output: %v", err)
 		}
 
 		if len(t.config.ExpectEvents) > 0 {

--- a/pkg/coordinator/tasks/generate_transaction/task.go
+++ b/pkg/coordinator/tasks/generate_transaction/task.go
@@ -51,24 +51,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_command/task.go
+++ b/pkg/coordinator/tasks/run_command/task.go
@@ -86,8 +86,11 @@ func (t *Task) Execute(ctx context.Context) error {
 	command := exec.CommandContext(ctx, com, args...)
 
 	stdOut, err := command.CombinedOutput()
+	t.ctx.Outputs.SetVar("stdout", string(stdOut))
+
 	if err != nil {
 		t.logger.WithField("stdout", string(stdOut)).WithError(err).Error("failed to run command")
+		t.ctx.Outputs.SetVar("error", err.Error())
 
 		if t.config.AllowedToFail {
 			return nil

--- a/pkg/coordinator/tasks/run_command/task.go
+++ b/pkg/coordinator/tasks/run_command/task.go
@@ -35,24 +35,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_shell/task.go
+++ b/pkg/coordinator/tasks/run_shell/task.go
@@ -39,24 +39,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_shell/task.go
+++ b/pkg/coordinator/tasks/run_shell/task.go
@@ -220,6 +220,7 @@ func (t *Task) readOutputStream(pipe io.ReadCloser, logger logrus.FieldLogger) c
 
 var outputVarPattern = regexp.MustCompile(`^::set-var +([^ ]+) +(.*)$`)
 var outputJSONPattern = regexp.MustCompile(`^::set-json +([^ ]+) +(.*)$`)
+var outputOutPattern = regexp.MustCompile(`^::set-out(put)?(-json)? +([^ ]+) +(.*)$`)
 
 func (t *Task) parseOutputVars(line string) bool {
 	match := outputVarPattern.FindStringSubmatch(line)
@@ -248,6 +249,32 @@ func (t *Task) parseOutputVars(line string) bool {
 			t.logger.Infof("set variable %v: (json) %v", match[1], varValue)
 
 			return true
+		}
+	}
+
+	match = outputOutPattern.FindStringSubmatch(line)
+	if match != nil {
+		var varValue interface{}
+
+		if match[2] == "-json" {
+			err := json.Unmarshal([]byte(match[4]), &varValue)
+			if err != nil {
+				t.logger.Warnf("error parsing ::set-output-json expression: %v", err.Error())
+			} else {
+				t.ctx.Outputs.SetVar(match[2], varValue)
+				t.logger.Infof("set output %v: (json) %v", match[3], varValue)
+
+				return true
+			}
+		} else {
+			t.ctx.Outputs.SetVar(match[3], match[4])
+
+			logValue := match[4]
+			if len(logValue) > 1024 {
+				logValue = fmt.Sprintf("(%v bytes)", len(logValue))
+			}
+
+			t.logger.Infof("set output %v: (string) %v", match[3], logValue)
 		}
 	}
 

--- a/pkg/coordinator/tasks/run_task_background/task.go
+++ b/pkg/coordinator/tasks/run_task_background/task.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,7 +82,10 @@ func (t *Task) LoadConfig() error {
 			return fmt.Errorf("failed parsing background task config: %w", err2)
 		}
 
-		t.backgroundTask, err = t.ctx.NewTask(bgTaskOpts, t.ctx.Vars.NewScope())
+		backgroundScope := t.ctx.Vars.NewScope()
+		t.ctx.Outputs.SetSubScope("backgroundScope", vars.NewScopeFilter(backgroundScope))
+
+		t.backgroundTask, err = t.ctx.NewTask(bgTaskOpts, backgroundScope)
 		if err != nil {
 			return fmt.Errorf("failed initializing background task: %w", err)
 		}
@@ -96,6 +100,7 @@ func (t *Task) LoadConfig() error {
 	taskVars := t.ctx.Vars
 	if config.NewVariableScope {
 		taskVars = taskVars.NewScope()
+		t.ctx.Outputs.SetSubScope("foregroundScope", vars.NewScopeFilter(taskVars))
 	}
 
 	t.foregroundTask, err = t.ctx.NewTask(fgTaskOpts, taskVars)

--- a/pkg/coordinator/tasks/run_task_background/task.go
+++ b/pkg/coordinator/tasks/run_task_background/task.go
@@ -45,24 +45,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_task_background/task.go
+++ b/pkg/coordinator/tasks/run_task_background/task.go
@@ -83,6 +83,7 @@ func (t *Task) LoadConfig() error {
 		}
 
 		backgroundScope := t.ctx.Vars.NewScope()
+		backgroundScope.SetVar("scopeOwner", uint64(t.ctx.Index))
 		t.ctx.Outputs.SetSubScope("backgroundScope", vars.NewScopeFilter(backgroundScope))
 
 		t.backgroundTask, err = t.ctx.NewTask(bgTaskOpts, backgroundScope)
@@ -100,6 +101,7 @@ func (t *Task) LoadConfig() error {
 	taskVars := t.ctx.Vars
 	if config.NewVariableScope {
 		taskVars = taskVars.NewScope()
+		taskVars.SetVar("scopeOwner", uint64(t.ctx.Index))
 		t.ctx.Outputs.SetSubScope("foregroundScope", vars.NewScopeFilter(taskVars))
 	}
 

--- a/pkg/coordinator/tasks/run_task_matrix/task.go
+++ b/pkg/coordinator/tasks/run_task_matrix/task.go
@@ -26,13 +26,13 @@ type Task struct {
 	config           Config
 	logger           logrus.FieldLogger
 	taskCtx          context.Context
-	tasks            []types.Task
-	taskIdxMap       map[types.Task]int
+	tasks            []types.TaskIndex
+	taskIdxMap       map[types.TaskIndex]int
 	resultNotifyChan chan taskResultUpdate
 }
 
 type taskResultUpdate struct {
-	task   types.Task
+	task   types.TaskIndex
 	result types.TaskResult
 }
 
@@ -41,7 +41,7 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 		ctx:              ctx,
 		options:          options,
 		logger:           ctx.Logger.GetLogger(),
-		taskIdxMap:       map[types.Task]int{},
+		taskIdxMap:       map[types.TaskIndex]int{},
 		resultNotifyChan: make(chan taskResultUpdate, 100),
 	}, nil
 }
@@ -92,7 +92,7 @@ func (t *Task) LoadConfig() error {
 	}
 
 	// init child tasks
-	childTasks := []types.Task{}
+	childTasks := []types.TaskIndex{}
 
 	for i := range config.MatrixValues {
 		taskOpts, err := t.ctx.Scheduler.ParseTaskOptions(config.Task)
@@ -183,7 +183,7 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	var successCount, failureCount, pendingCount uint64
 
-	resultMap := map[types.Task]types.TaskResult{}
+	resultMap := map[types.TaskIndex]types.TaskResult{}
 
 	taskComplete := false
 	for !taskComplete {
@@ -243,12 +243,13 @@ func (t *Task) Execute(ctx context.Context) error {
 	return nil
 }
 
-func (t *Task) watchChildTask(_ context.Context, _ context.CancelFunc, task types.Task) {
+func (t *Task) watchChildTask(_ context.Context, _ context.CancelFunc, taskIndex types.TaskIndex) {
+	taskState := t.ctx.Scheduler.GetTaskState(taskIndex)
 	oldStatus := types.TaskResultNone
 	taskActive := true
 
 	for taskActive {
-		updateChan := t.ctx.Scheduler.GetTaskResultUpdateChan(task, oldStatus)
+		updateChan := taskState.GetTaskResultUpdateChan(oldStatus)
 		if updateChan != nil {
 			select {
 			case <-t.taskCtx.Done():
@@ -258,7 +259,7 @@ func (t *Task) watchChildTask(_ context.Context, _ context.CancelFunc, task type
 			}
 		}
 
-		taskStatus := t.ctx.Scheduler.GetTaskStatus(task)
+		taskStatus := taskState.GetTaskStatus()
 		if !taskStatus.IsRunning {
 			taskActive = false
 		}
@@ -267,10 +268,10 @@ func (t *Task) watchChildTask(_ context.Context, _ context.CancelFunc, task type
 			continue
 		}
 
-		t.logger.Debugf("result update notification for task %v (%v -> %v)", t.taskIdxMap[task], oldStatus, taskStatus.Result)
+		t.logger.Debugf("result update notification for task %v (%v -> %v)", t.taskIdxMap[taskIndex], oldStatus, taskStatus.Result)
 
 		t.resultNotifyChan <- taskResultUpdate{
-			task:   task,
+			task:   taskIndex,
 			result: taskStatus.Result,
 		}
 

--- a/pkg/coordinator/tasks/run_task_matrix/task.go
+++ b/pkg/coordinator/tasks/run_task_matrix/task.go
@@ -87,6 +87,8 @@ func (t *Task) LoadConfig() error {
 		}
 
 		taskVars := t.ctx.Vars.NewScope()
+		taskVars.SetVar("scopeOwner", uint64(t.ctx.Index))
+
 		if config.MatrixVar != "" {
 			taskVars.SetVar(config.MatrixVar, config.MatrixValues[i])
 		}

--- a/pkg/coordinator/tasks/run_task_matrix/task.go
+++ b/pkg/coordinator/tasks/run_task_matrix/task.go
@@ -46,24 +46,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_task_matrix/task.go
+++ b/pkg/coordinator/tasks/run_task_matrix/task.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/sirupsen/logrus"
 )
 
@@ -77,6 +78,7 @@ func (t *Task) LoadConfig() error {
 
 	// init child tasks
 	childTasks := []types.TaskIndex{}
+	childScopes := vars.NewVariables(nil)
 
 	for i := range config.MatrixValues {
 		taskOpts, err := t.ctx.Scheduler.ParseTaskOptions(config.Task)
@@ -95,7 +97,11 @@ func (t *Task) LoadConfig() error {
 		}
 
 		childTasks = append(childTasks, task)
+
+		childScopes.SetSubScope(fmt.Sprintf("%v", i), vars.NewScopeFilter(taskVars))
 	}
+
+	t.ctx.Outputs.SetSubScope("childScopes", childScopes)
 
 	t.config = config
 	t.tasks = childTasks

--- a/pkg/coordinator/tasks/run_task_options/task.go
+++ b/pkg/coordinator/tasks/run_task_options/task.go
@@ -85,7 +85,7 @@ func (t *Task) Execute(ctx context.Context) error {
 		taskVars := t.ctx.Vars
 		if t.config.NewVariableScope {
 			taskVars = taskVars.NewScope()
-
+			taskVars.SetVar("scopeOwner", uint64(t.ctx.Index))
 			t.ctx.Outputs.SetSubScope("childScope", vars.NewScopeFilter(taskVars))
 		}
 

--- a/pkg/coordinator/tasks/run_task_options/task.go
+++ b/pkg/coordinator/tasks/run_task_options/task.go
@@ -35,24 +35,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_task_options/task.go
+++ b/pkg/coordinator/tasks/run_task_options/task.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/vars"
 	"github.com/sirupsen/logrus"
 )
 
@@ -84,6 +85,8 @@ func (t *Task) Execute(ctx context.Context) error {
 		taskVars := t.ctx.Vars
 		if t.config.NewVariableScope {
 			taskVars = taskVars.NewScope()
+
+			t.ctx.Outputs.SetSubScope("childScope", vars.NewScopeFilter(taskVars))
 		}
 
 		t.task, err = t.ctx.NewTask(taskOpts, taskVars)

--- a/pkg/coordinator/tasks/run_tasks/README.md
+++ b/pkg/coordinator/tasks/run_tasks/README.md
@@ -24,6 +24,9 @@ An important aspect of this task is that it cancels tasks once they return a res
 - **`continueOnFailure`**:\
   When `true`, the sequence of tasks continues even if individual tasks fail, allowing the entire sequence to be executed regardless of individual task outcomes.
 
+- **`newVariableScope`**:\
+  Determines whether to create a new variable scope for the child tasks. If `false`, the current scope is passed through, allowing the child tasks to share the same variable context as the `run_tasks` task.
+
 ### Defaults
 
 Default settings for the `run_tasks` task:
@@ -35,4 +38,5 @@ Default settings for the `run_tasks` task:
     stopChildOnResult: true
     expectFailure: false
     continueOnFailure: false
+    newVariableScope: false
 ```

--- a/pkg/coordinator/tasks/run_tasks/config.go
+++ b/pkg/coordinator/tasks/run_tasks/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	StopChildOnResult bool                `yaml:"stopChildOnResult" json:"stopChildOnResult"`
 	ExpectFailure     bool                `yaml:"expectFailure" json:"expectFailure"`
 	ContinueOnFailure bool                `yaml:"continueOnFailure" json:"continueOnFailure"`
+	NewVariableScope  bool                `yaml:"newVariableScope" json:"newVariableScope"`
 }
 
 func DefaultConfig() Config {

--- a/pkg/coordinator/tasks/run_tasks/task.go
+++ b/pkg/coordinator/tasks/run_tasks/task.go
@@ -24,7 +24,7 @@ type Task struct {
 	options *types.TaskOptions
 	config  Config
 	logger  logrus.FieldLogger
-	tasks   []types.Task
+	tasks   []types.TaskIndex
 }
 
 func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, error) {
@@ -81,7 +81,7 @@ func (t *Task) LoadConfig() error {
 	}
 
 	// init child tasks
-	childTasks := []types.Task{}
+	childTasks := []types.TaskIndex{}
 
 	for i := range config.Tasks {
 		taskOpts, err := t.ctx.Scheduler.ParseTaskOptions(&config.Tasks[i])
@@ -105,7 +105,7 @@ func (t *Task) LoadConfig() error {
 
 func (t *Task) Execute(ctx context.Context) error {
 	for i, task := range t.tasks {
-		err := t.ctx.Scheduler.ExecuteTask(ctx, task, func(ctx context.Context, cancelFn context.CancelFunc, task types.Task) {
+		err := t.ctx.Scheduler.ExecuteTask(ctx, task, func(ctx context.Context, cancelFn context.CancelFunc, task types.TaskIndex) {
 			if t.config.StopChildOnResult {
 				t.ctx.Scheduler.WatchTaskPass(ctx, cancelFn, task)
 			}

--- a/pkg/coordinator/tasks/run_tasks/task.go
+++ b/pkg/coordinator/tasks/run_tasks/task.go
@@ -35,24 +35,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/run_tasks/task.go
+++ b/pkg/coordinator/tasks/run_tasks/task.go
@@ -67,13 +67,20 @@ func (t *Task) LoadConfig() error {
 	// init child tasks
 	childTasks := []types.TaskIndex{}
 
+	var taskVars types.Variables
+
+	if t.config.NewVariableScope {
+		taskVars = t.ctx.Vars.NewScope()
+		t.ctx.Outputs.SetSubScope("childScope", taskVars)
+	}
+
 	for i := range config.Tasks {
 		taskOpts, err := t.ctx.Scheduler.ParseTaskOptions(&config.Tasks[i])
 		if err != nil {
 			return fmt.Errorf("failed parsing child task config #%v : %w", i+1, err)
 		}
 
-		task, err := t.ctx.NewTask(taskOpts, nil)
+		task, err := t.ctx.NewTask(taskOpts, taskVars)
 		if err != nil {
 			return fmt.Errorf("failed initializing child task #%v : %w", i+1, err)
 		}

--- a/pkg/coordinator/tasks/run_tasks/task.go
+++ b/pkg/coordinator/tasks/run_tasks/task.go
@@ -71,6 +71,7 @@ func (t *Task) LoadConfig() error {
 
 	if t.config.NewVariableScope {
 		taskVars = t.ctx.Vars.NewScope()
+		taskVars.SetVar("scopeOwner", uint64(t.ctx.Index))
 		t.ctx.Outputs.SetSubScope("childScope", taskVars)
 	}
 

--- a/pkg/coordinator/tasks/run_tasks_concurrent/task.go
+++ b/pkg/coordinator/tasks/run_tasks_concurrent/task.go
@@ -87,6 +87,7 @@ func (t *Task) LoadConfig() error {
 		}
 
 		taskVars := t.ctx.Vars.NewScope()
+		taskVars.SetVar("scopeOwner", uint64(t.ctx.Index))
 
 		task, err := t.ctx.NewTask(taskOpts, taskVars)
 		if err != nil {

--- a/pkg/coordinator/tasks/run_tasks_concurrent/task.go
+++ b/pkg/coordinator/tasks/run_tasks_concurrent/task.go
@@ -46,24 +46,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskName
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/tasks/sleep/task.go
+++ b/pkg/coordinator/tasks/sleep/task.go
@@ -34,24 +34,8 @@ func NewTask(ctx *types.TaskContext, options *types.TaskOptions) (types.Task, er
 	}, nil
 }
 
-func (t *Task) Name() string {
-	return TaskDescriptor.Name
-}
-
-func (t *Task) Title() string {
-	return t.ctx.Vars.ResolvePlaceholders(t.options.Title)
-}
-
-func (t *Task) Description() string {
-	return TaskDescriptor.Description
-}
-
 func (t *Task) Config() interface{} {
 	return t.config
-}
-
-func (t *Task) Logger() logrus.FieldLogger {
-	return t.logger
 }
 
 func (t *Task) Timeout() time.Duration {

--- a/pkg/coordinator/test/descriptor.go
+++ b/pkg/coordinator/test/descriptor.go
@@ -147,7 +147,7 @@ func LoadExternalTestConfig(ctx context.Context, globalVars types.Variables, ext
 		return nil, nil, fmt.Errorf("error decoding external test configVars %v: %v", extTestCfg.File, err)
 	}
 
-	for k, v := range globalVars.GetVarsMap() {
+	for k, v := range globalVars.GetVarsMap(nil) {
 		testVars.SetVar(k, v)
 	}
 

--- a/pkg/coordinator/test/descriptor.go
+++ b/pkg/coordinator/test/descriptor.go
@@ -147,7 +147,7 @@ func LoadExternalTestConfig(ctx context.Context, globalVars types.Variables, ext
 		return nil, nil, fmt.Errorf("error decoding external test configVars %v: %v", extTestCfg.File, err)
 	}
 
-	for k, v := range globalVars.GetVarsMap(nil) {
+	for k, v := range globalVars.GetVarsMap(nil, false) {
 		testVars.SetVar(k, v)
 	}
 

--- a/pkg/coordinator/types/scheduler.go
+++ b/pkg/coordinator/types/scheduler.go
@@ -12,15 +12,14 @@ import (
 type TaskScheduler interface {
 	GetServices() TaskServices
 	ParseTaskOptions(rawtask *helper.RawMessage) (*TaskOptions, error)
-	ExecuteTask(ctx context.Context, task Task, taskWatchFn func(ctx context.Context, cancelFn context.CancelFunc, task Task)) error
-	WatchTaskPass(ctx context.Context, cancelFn context.CancelFunc, task Task)
+	ExecuteTask(ctx context.Context, taskIndex TaskIndex, taskWatchFn func(ctx context.Context, cancelFn context.CancelFunc, taskIndex TaskIndex)) error
+	WatchTaskPass(ctx context.Context, cancelFn context.CancelFunc, taskIndex TaskIndex)
+	GetTaskState(taskIndex TaskIndex) TaskState
 	GetTaskCount() int
-	GetAllTasks() []Task
-	GetRootTasks() []Task
-	GetAllCleanupTasks() []Task
-	GetRootCleanupTasks() []Task
-	GetTaskStatus(task Task) *TaskStatus
-	GetTaskResultUpdateChan(task Task, oldResult TaskResult) <-chan bool
+	GetAllTasks() []TaskIndex
+	GetRootTasks() []TaskIndex
+	GetAllCleanupTasks() []TaskIndex
+	GetRootCleanupTasks() []TaskIndex
 }
 
 type TaskServices interface {

--- a/pkg/coordinator/types/task.go
+++ b/pkg/coordinator/types/task.go
@@ -26,6 +26,8 @@ type TaskOptions struct {
 	Title string `yaml:"title" json:"title"`
 	// Timeout defines the max time waiting for the condition to be met.
 	Timeout helper.Duration `yaml:"timeout" json:"timeout"`
+	// The optional id of the task (for result access via steps.<step-id>).
+	ID string `yaml:"id" json:"id"`
 }
 
 type TaskIndex uint64
@@ -48,12 +50,14 @@ type Task interface {
 type TaskState interface {
 	Index() TaskIndex
 	ParentIndex() TaskIndex
+	ID() string
 	Name() string
 	Title() string
 	Description() string
 	Config() interface{}
 	Timeout() time.Duration
 	GetTaskStatus() *TaskStatus
+	GetTaskStatusVars() Variables
 	GetTaskResultUpdateChan(oldResult TaskResult) <-chan bool
 }
 

--- a/pkg/coordinator/types/task.go
+++ b/pkg/coordinator/types/task.go
@@ -26,7 +26,7 @@ type TaskOptions struct {
 	Title string `yaml:"title" json:"title"`
 	// Timeout defines the max time waiting for the condition to be met.
 	Timeout helper.Duration `yaml:"timeout" json:"timeout"`
-	// The optional id of the task (for result access via steps.<step-id>).
+	// The optional id of the task (for result access via tasks.<task-id>).
 	ID string `yaml:"id" json:"id"`
 }
 

--- a/pkg/coordinator/types/task.go
+++ b/pkg/coordinator/types/task.go
@@ -77,6 +77,7 @@ type TaskContext struct {
 	Scheduler TaskScheduler
 	Index     TaskIndex
 	Vars      Variables
+	Outputs   Variables
 	Logger    *logger.LogScope
 	NewTask   func(options *TaskOptions, variables Variables) (TaskIndex, error)
 	SetResult func(result TaskResult)

--- a/pkg/coordinator/types/task.go
+++ b/pkg/coordinator/types/task.go
@@ -58,6 +58,7 @@ type TaskState interface {
 	Timeout() time.Duration
 	GetTaskStatus() *TaskStatus
 	GetTaskStatusVars() Variables
+	GetTaskVars() Variables
 	GetTaskResultUpdateChan(oldResult TaskResult) <-chan bool
 }
 

--- a/pkg/coordinator/types/vars.go
+++ b/pkg/coordinator/types/vars.go
@@ -5,8 +5,10 @@ type Variables interface {
 	LookupVar(name string) (interface{}, bool)
 	ResolveQuery(query string) (interface{}, bool, error)
 	SetVar(name string, value interface{})
+	GetSubScope(name string) Variables
 	NewScope() Variables
-	GetVarsMap() map[string]any
+	GetVarsMap(varsMap map[string]any) map[string]any
+	GetChildVarsMap() map[string]any
 	ResolvePlaceholders(str string) string
 	ConsumeVars(config interface{}, consumeMap map[string]string) error
 	CopyVars(source Variables, copyMap map[string]string) error

--- a/pkg/coordinator/types/vars.go
+++ b/pkg/coordinator/types/vars.go
@@ -5,7 +5,6 @@ type Variables interface {
 	LookupVar(name string) (interface{}, bool)
 	ResolveQuery(query string) (interface{}, bool, error)
 	SetVar(name string, value interface{})
-	NewSubScope(name string) Variables
 	GetSubScope(name string) Variables
 	SetSubScope(name string, subScope Variables)
 	NewScope() Variables

--- a/pkg/coordinator/types/vars.go
+++ b/pkg/coordinator/types/vars.go
@@ -5,7 +5,9 @@ type Variables interface {
 	LookupVar(name string) (interface{}, bool)
 	ResolveQuery(query string) (interface{}, bool, error)
 	SetVar(name string, value interface{})
+	NewSubScope(name string) Variables
 	GetSubScope(name string) Variables
+	SetSubScope(name string, subScope Variables)
 	NewScope() Variables
 	GetVarsMap(varsMap map[string]any) map[string]any
 	GetChildVarsMap() map[string]any

--- a/pkg/coordinator/types/vars.go
+++ b/pkg/coordinator/types/vars.go
@@ -9,8 +9,7 @@ type Variables interface {
 	GetSubScope(name string) Variables
 	SetSubScope(name string, subScope Variables)
 	NewScope() Variables
-	GetVarsMap(varsMap map[string]any) map[string]any
-	GetChildVarsMap() map[string]any
+	GetVarsMap(varsMap map[string]any, skipParent bool) map[string]any
 	ResolvePlaceholders(str string) string
 	ConsumeVars(config interface{}, consumeMap map[string]string) error
 	CopyVars(source Variables, copyMap map[string]string) error

--- a/pkg/coordinator/vars/scope_filter.go
+++ b/pkg/coordinator/vars/scope_filter.go
@@ -26,10 +26,6 @@ func (v *ScopeFilter) SetVar(name string, value interface{}) {
 	v.vars.SetVar(name, value)
 }
 
-func (v *ScopeFilter) NewSubScope(name string) types.Variables {
-	return v.vars.NewSubScope(name)
-}
-
 func (v *ScopeFilter) GetSubScope(name string) types.Variables {
 	return v.vars.GetSubScope(name)
 }

--- a/pkg/coordinator/vars/scope_filter.go
+++ b/pkg/coordinator/vars/scope_filter.go
@@ -1,0 +1,63 @@
+package vars
+
+import (
+	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+)
+
+type ScopeFilter struct {
+	vars types.Variables
+}
+
+func NewScopeFilter(vars types.Variables) types.Variables {
+	return &ScopeFilter{
+		vars: vars,
+	}
+}
+
+func (v *ScopeFilter) GetVar(name string) interface{} {
+	return v.vars.GetVar(name)
+}
+
+func (v *ScopeFilter) LookupVar(name string) (interface{}, bool) {
+	return v.vars.LookupVar(name)
+}
+
+func (v *ScopeFilter) SetVar(name string, value interface{}) {
+	v.vars.SetVar(name, value)
+}
+
+func (v *ScopeFilter) NewSubScope(name string) types.Variables {
+	return v.vars.NewSubScope(name)
+}
+
+func (v *ScopeFilter) GetSubScope(name string) types.Variables {
+	return v.vars.GetSubScope(name)
+}
+
+func (v *ScopeFilter) SetSubScope(name string, subScope types.Variables) {
+	v.vars.SetSubScope(name, subScope)
+}
+
+func (v *ScopeFilter) NewScope() types.Variables {
+	return v.vars.NewScope()
+}
+
+func (v *ScopeFilter) ResolvePlaceholders(str string) string {
+	return v.vars.ResolvePlaceholders(str)
+}
+
+func (v *ScopeFilter) GetVarsMap(varsMap map[string]any, _ bool) map[string]any {
+	return v.vars.GetVarsMap(varsMap, true)
+}
+
+func (v *ScopeFilter) ResolveQuery(queryStr string) (value interface{}, found bool, err error) {
+	return v.vars.ResolveQuery(queryStr)
+}
+
+func (v *ScopeFilter) ConsumeVars(config interface{}, consumeMap map[string]string) error {
+	return v.vars.ConsumeVars(config, consumeMap)
+}
+
+func (v *ScopeFilter) CopyVars(source types.Variables, copyMap map[string]string) error {
+	return v.vars.CopyVars(source, copyMap)
+}

--- a/pkg/coordinator/vars/utils.go
+++ b/pkg/coordinator/vars/utils.go
@@ -1,0 +1,22 @@
+package vars
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func GeneralizeData(source interface{}) (interface{}, error) {
+	jsonData, err := json.Marshal(&source)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal: %v", err)
+	}
+
+	target := map[string]any{}
+
+	err = json.Unmarshal(jsonData, &target)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal: %v\n%v", err, string(jsonData))
+	}
+
+	return target, nil
+}

--- a/pkg/coordinator/vars/utils.go
+++ b/pkg/coordinator/vars/utils.go
@@ -11,7 +11,7 @@ func GeneralizeData(source interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("could not marshal: %v", err)
 	}
 
-	target := map[string]any{}
+	var target interface{}
 
 	err = json.Unmarshal(jsonData, &target)
 	if err != nil {

--- a/pkg/coordinator/wallet/wallet.go
+++ b/pkg/coordinator/wallet/wallet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethpandaops/assertoor/pkg/coordinator/clients/execution"
 	"github.com/sirupsen/logrus"
 )
@@ -37,6 +38,15 @@ type Wallet struct {
 
 	txNonceChans map[uint64]*nonceStatus
 	txNonceMutex sync.Mutex
+}
+
+type Summary struct {
+	Address          string   `json:"address"`
+	PrivKey          string   `json:"privkey"`
+	PendingBalance   *big.Int `json:"pendingBalance"`
+	PendingNonce     uint64   `json:"pendingNonce"`
+	ConfirmedBalance *big.Int `json:"confirmedBalance"`
+	ConfirmedNonce   uint64   `json:"confirmedNonce"`
 }
 
 type nonceStatus struct {
@@ -134,6 +144,17 @@ func (wallet *Wallet) GetPendingBalance() *big.Int {
 
 func (wallet *Wallet) GetNonce() uint64 {
 	return wallet.confirmedNonce
+}
+
+func (wallet *Wallet) GetSummary() *Summary {
+	return &Summary{
+		Address:          wallet.address.String(),
+		PrivKey:          fmt.Sprintf("%x", crypto.FromECDSA(wallet.privkey)),
+		PendingBalance:   wallet.pendingBalance,
+		PendingNonce:     wallet.pendingNonce,
+		ConfirmedBalance: wallet.confirmedBalance,
+		ConfirmedNonce:   wallet.confirmedNonce,
+	}
 }
 
 func (wallet *Wallet) GetReadableBalance(unitDigits, maxPreCommaDigitsBeforeTrim, digits int, addPositiveSign, trimAmount bool) string {

--- a/pkg/coordinator/web/api/docs/docs.go
+++ b/pkg/coordinator/web/api/docs/docs.go
@@ -635,6 +635,9 @@ const docTemplate = `{
                 "result_error": {
                     "type": "string"
                 },
+                "result_yaml": {
+                    "type": "string"
+                },
                 "runtime": {
                     "type": "integer"
                 },

--- a/pkg/coordinator/web/api/docs/swagger.json
+++ b/pkg/coordinator/web/api/docs/swagger.json
@@ -627,6 +627,9 @@
                 "result_error": {
                     "type": "string"
                 },
+                "result_yaml": {
+                    "type": "string"
+                },
                 "runtime": {
                     "type": "integer"
                 },

--- a/pkg/coordinator/web/api/docs/swagger.yaml
+++ b/pkg/coordinator/web/api/docs/swagger.yaml
@@ -39,6 +39,8 @@ definitions:
         type: string
       result_error:
         type: string
+      result_yaml:
+        type: string
       runtime:
         type: integer
       start_time:

--- a/pkg/coordinator/web/api/get_test_run_api.go
+++ b/pkg/coordinator/web/api/get_test_run_api.go
@@ -82,16 +82,17 @@ func (ah *APIHandler) GetTestRun(w http.ResponseWriter, r *http.Request) {
 	taskScheduler := testInstance.GetTaskScheduler()
 	if taskScheduler != nil && taskScheduler.GetTaskCount() > 0 {
 		for _, task := range taskScheduler.GetAllTasks() {
-			taskStatus := taskScheduler.GetTaskStatus(task)
+			taskState := taskScheduler.GetTaskState(task)
+			taskStatus := taskState.GetTaskStatus()
 
 			taskData := &GetTestRunTask{
-				Index:       taskStatus.Index,
-				ParentIndex: taskStatus.ParentIndex,
-				Name:        task.Name(),
-				Title:       task.Title(),
+				Index:       uint64(taskState.Index()),
+				ParentIndex: uint64(taskState.ParentIndex()),
+				Name:        taskState.Name(),
+				Title:       taskState.Title(),
 				Started:     taskStatus.IsStarted,
 				Completed:   taskStatus.IsStarted && !taskStatus.IsRunning,
-				Timeout:     uint64(task.Timeout().Seconds()),
+				Timeout:     uint64(taskState.Timeout().Seconds()),
 			}
 
 			switch {

--- a/pkg/coordinator/web/api/get_test_run_details_api.go
+++ b/pkg/coordinator/web/api/get_test_run_details_api.go
@@ -94,16 +94,17 @@ func (ah *APIHandler) GetTestRunDetails(w http.ResponseWriter, r *http.Request) 
 	taskScheduler := testInstance.GetTaskScheduler()
 	if taskScheduler != nil && taskScheduler.GetTaskCount() > 0 {
 		for _, task := range taskScheduler.GetAllTasks() {
-			taskStatus := taskScheduler.GetTaskStatus(task)
+			taskState := taskScheduler.GetTaskState(task)
+			taskStatus := taskState.GetTaskStatus()
 
 			taskData := &GetTestRunDetailedTask{
-				Index:       taskStatus.Index,
-				ParentIndex: taskStatus.ParentIndex,
-				Name:        task.Name(),
-				Title:       task.Title(),
+				Index:       uint64(taskState.Index()),
+				ParentIndex: uint64(taskState.ParentIndex()),
+				Name:        taskState.Name(),
+				Title:       taskState.Title(),
 				Started:     taskStatus.IsStarted,
 				Completed:   taskStatus.IsStarted && !taskStatus.IsRunning,
-				Timeout:     uint64(task.Timeout().Seconds()),
+				Timeout:     uint64(taskState.Timeout().Seconds()),
 			}
 
 			switch {
@@ -152,7 +153,7 @@ func (ah *APIHandler) GetTestRunDetails(w http.ResponseWriter, r *http.Request) 
 				taskData.Log[i] = logData
 			}
 
-			taskConfig, err := yaml.Marshal(task.Config())
+			taskConfig, err := yaml.Marshal(taskState.Config())
 			if err != nil {
 				taskData.ConfigYaml = fmt.Sprintf("failed marshalling config: %v", err)
 			} else {

--- a/pkg/coordinator/web/api/get_test_run_details_api.go
+++ b/pkg/coordinator/web/api/get_test_run_details_api.go
@@ -37,6 +37,7 @@ type GetTestRunDetailedTask struct {
 	ResultError string                       `json:"result_error"`
 	Log         []*GetTestRunDetailedTaskLog `json:"log"`
 	ConfigYaml  string                       `json:"config_yaml"`
+	ResultYaml  string                       `json:"result_yaml"`
 }
 
 type GetTestRunDetailedTaskLog struct {
@@ -158,6 +159,13 @@ func (ah *APIHandler) GetTestRunDetails(w http.ResponseWriter, r *http.Request) 
 				taskData.ConfigYaml = fmt.Sprintf("failed marshalling config: %v", err)
 			} else {
 				taskData.ConfigYaml = string(taskConfig)
+			}
+
+			taskResult, err := yaml.Marshal(taskState.GetTaskStatusVars().GetVarsMap(nil, false))
+			if err != nil {
+				taskData.ResultYaml = fmt.Sprintf("failed marshalling result: %v", err)
+			} else {
+				taskData.ResultYaml = string(taskResult)
 			}
 
 			response.Tasks = append(response.Tasks, taskData)

--- a/pkg/coordinator/web/api/post_test_run_api.go
+++ b/pkg/coordinator/web/api/post_test_run_api.go
@@ -75,6 +75,6 @@ func (ah *APIHandler) PostTestRunsSchedule(w http.ResponseWriter, r *http.Reques
 		TestID: testDescriptor.ID(),
 		RunID:  testInstance.RunID(),
 		Name:   testInstance.Name(),
-		Config: testInstance.GetTestVariables().GetVarsMap(nil),
+		Config: testInstance.GetTestVariables().GetVarsMap(nil, false),
 	})
 }

--- a/pkg/coordinator/web/api/post_test_run_api.go
+++ b/pkg/coordinator/web/api/post_test_run_api.go
@@ -75,6 +75,6 @@ func (ah *APIHandler) PostTestRunsSchedule(w http.ResponseWriter, r *http.Reques
 		TestID: testDescriptor.ID(),
 		RunID:  testInstance.RunID(),
 		Name:   testInstance.Name(),
-		Config: testInstance.GetTestVariables().GetVarsMap(),
+		Config: testInstance.GetTestVariables().GetVarsMap(nil),
 	})
 }

--- a/pkg/coordinator/web/handlers/test.go
+++ b/pkg/coordinator/web/handlers/test.go
@@ -108,7 +108,7 @@ func (fh *FrontendHandler) getTestPageData(testID string) (*TestPage, error) {
 		Source: testDescriptor.Source(),
 	}
 
-	testCfgJSON, err := json.Marshal(testDescriptor.Vars().GetVarsMap())
+	testCfgJSON, err := json.Marshal(testDescriptor.Vars().GetVarsMap(nil))
 	if err != nil {
 		return nil, fmt.Errorf("failed marshalling test vars: %v", err)
 	}

--- a/pkg/coordinator/web/handlers/test.go
+++ b/pkg/coordinator/web/handlers/test.go
@@ -108,7 +108,7 @@ func (fh *FrontendHandler) getTestPageData(testID string) (*TestPage, error) {
 		Source: testDescriptor.Source(),
 	}
 
-	testCfgJSON, err := json.Marshal(testDescriptor.Vars().GetVarsMap(nil))
+	testCfgJSON, err := json.Marshal(testDescriptor.Vars().GetVarsMap(nil, false))
 	if err != nil {
 		return nil, fmt.Errorf("failed marshalling test vars: %v", err)
 	}

--- a/pkg/coordinator/web/handlers/test_run.go
+++ b/pkg/coordinator/web/handlers/test_run.go
@@ -260,7 +260,20 @@ func (fh *FrontendHandler) getTestRunPageData(runID int64) (*TestRunPage, error)
 			if err != nil {
 				taskData.ResultYaml = fmt.Sprintf("failed marshalling result: %v", err)
 			} else {
-				taskData.ResultYaml = fmt.Sprintf("\n%v\n", string(taskResult))
+				refComment := ""
+
+				if taskState.ID() != "" {
+					scopeOwner := taskState.GetTaskVars().GetVar("scopeOwner")
+					if scopeOwner != nil {
+						scopeOwner = fmt.Sprintf("task %v", scopeOwner)
+					} else {
+						scopeOwner = "root"
+					}
+
+					refComment = fmt.Sprintf("# available from %v scope via `tasks.%v`:\n", scopeOwner, taskState.ID())
+				}
+
+				taskData.ResultYaml = fmt.Sprintf("\n%v%v\n", refComment, string(taskResult))
 			}
 
 			pageData.Tasks = append(pageData.Tasks, taskData)

--- a/pkg/coordinator/web/handlers/test_run.go
+++ b/pkg/coordinator/web/handlers/test_run.go
@@ -46,6 +46,7 @@ type TestRunTask struct {
 	ResultError string            `json:"result_error"`
 	Log         []*TestRunTaskLog `json:"log"`
 	ConfigYaml  string            `json:"config_yaml"`
+	ResultYaml  string            `json:"result_yaml"`
 }
 
 type TestRunTaskLog struct {
@@ -252,7 +253,14 @@ func (fh *FrontendHandler) getTestRunPageData(runID int64) (*TestRunPage, error)
 			if err != nil {
 				taskData.ConfigYaml = fmt.Sprintf("failed marshalling config: %v", err)
 			} else {
-				taskData.ConfigYaml = string(taskConfig)
+				taskData.ConfigYaml = fmt.Sprintf("\n%v\n", string(taskConfig))
+			}
+
+			taskResult, err := yaml.Marshal(taskState.GetTaskStatusVars().GetVarsMap(nil, false))
+			if err != nil {
+				taskData.ResultYaml = fmt.Sprintf("failed marshalling result: %v", err)
+			} else {
+				taskData.ResultYaml = fmt.Sprintf("\n%v\n", string(taskResult))
 			}
 
 			pageData.Tasks = append(pageData.Tasks, taskData)

--- a/pkg/coordinator/web/handlers/test_run.go
+++ b/pkg/coordinator/web/handlers/test_run.go
@@ -158,19 +158,20 @@ func (fh *FrontendHandler) getTestRunPageData(runID int64) (*TestRunPage, error)
 		indentationMap := map[uint64]int{}
 
 		for idx, task := range taskScheduler.GetAllTasks() {
-			taskStatus := taskScheduler.GetTaskStatus(task)
+			taskState := taskScheduler.GetTaskState(task)
+			taskStatus := taskState.GetTaskStatus()
 
 			taskData := &TestRunTask{
-				Index:       taskStatus.Index,
-				ParentIndex: taskStatus.ParentIndex,
-				Name:        task.Name(),
-				Title:       task.Title(),
+				Index:       uint64(taskState.Index()),
+				ParentIndex: uint64(taskState.ParentIndex()),
+				Name:        taskState.Name(),
+				Title:       taskState.Title(),
 				IsStarted:   taskStatus.IsStarted,
 				IsCompleted: taskStatus.IsStarted && !taskStatus.IsRunning,
 				StartTime:   taskStatus.StartTime,
 				StopTime:    taskStatus.StopTime,
-				Timeout:     task.Timeout(),
-				HasTimeout:  task.Timeout() > 0,
+				Timeout:     taskState.Timeout(),
+				HasTimeout:  taskState.Timeout() > 0,
 				GraphLevels: []uint64{},
 			}
 
@@ -247,7 +248,7 @@ func (fh *FrontendHandler) getTestRunPageData(runID int64) (*TestRunPage, error)
 				taskData.Log[i] = logData
 			}
 
-			taskConfig, err := yaml.Marshal(task.Config())
+			taskConfig, err := yaml.Marshal(taskState.Config())
 			if err != nil {
 				taskData.ConfigYaml = fmt.Sprintf("failed marshalling config: %v", err)
 			} else {

--- a/pkg/coordinator/web/templates/test_run/test_run.html
+++ b/pkg/coordinator/web/templates/test_run/test_run.html
@@ -215,6 +215,9 @@
                     <li class="nav-item" role="presentation">
                       <button class="nav-link" id="task{{ $task.Index }}-config-tab" data-bs-toggle="tab" data-bs-target="#task{{ $task.Index }}-config" type="button" role="tab" aria-controls="task{{ $task.Index }}-config" aria-selected="false">Config</button>
                     </li>
+                    <li class="nav-item" role="presentation">
+                      <button class="nav-link" id="task{{ $task.Index }}-result-tab" data-bs-toggle="tab" data-bs-target="#task{{ $task.Index }}-result" type="button" role="tab" aria-controls="task{{ $task.Index }}-result" aria-selected="false">Result</button>
+                    </li>
                   </ul>
                   <div class="card">
                     <div class="tab-content card-body" id="task{{ $task.Index }}-tabcontent">
@@ -255,9 +258,10 @@
                         </div>
                       </div>
                       <div class="tab-pane fade card-body" id="task{{ $task.Index }}-config" role="tabpanel" aria-labelledby="task{{ $task.Index }}-config-tab">
-<pre>
-{{ $task.ConfigYaml }}</pre>
-
+                        <pre>{{ $task.ConfigYaml }}</pre>
+                      </div>
+                      <div class="tab-pane fade card-body" id="task{{ $task.Index }}-result" role="tabpanel" aria-labelledby="task{{ $task.Index }}-result-tab">
+                        <pre>{{ $task.ResultYaml }}</pre>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Task scheduler improvements
* [x] decouple task state from task instance
  - this reduces memory consumption as all task instances get dropped from memory after execution.
  - pre-work for possible persistence in future.
* [x] add task outputs
  - add optional task Id
  - show task results (including outputs on UI)
  - allow access to other task results via `tasks.<task-id>.*` in variable system