### PR TITLE
fix: run_shell - use correct key when using ::set-out(put)-json

### DIFF
--- a/pkg/coordinator/tasks/run_shell/task.go
+++ b/pkg/coordinator/tasks/run_shell/task.go
@@ -261,7 +261,7 @@ func (t *Task) parseOutputVars(line string) bool {
 			if err != nil {
 				t.logger.Warnf("error parsing ::set-output-json expression: %v", err.Error())
 			} else {
-				t.ctx.Outputs.SetVar(match[2], varValue)
+				t.ctx.Outputs.SetVar(match[3], varValue)
 				t.logger.Infof("set output %v: (json) %v", match[3], varValue)
 
 				return true


### PR DESCRIPTION
Right now it was matching `-json` instead of the actual key, which is on the next position. Which resulted in a weird output with a `-json` key. 

Example: https://regex101.com/r/BOzPTn/1 