### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -46,13 +46,13 @@ jobs:
     name: Build linux/amd64 binary
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
     
@@ -71,7 +71,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: assertoor_linux_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: assertoor_linux_amd64
@@ -80,13 +80,13 @@ jobs:
     name: Build linux/arm64 binary
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -111,7 +111,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: assertoor_linux_arm64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: assertoor_linux_arm64
@@ -120,13 +120,13 @@ jobs:
     name: Build windows/amd64 binary
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -145,7 +145,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: assertoor_windows_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: assertoor_windows_amd64
@@ -154,13 +154,13 @@ jobs:
     name: Build macos/amd64 binary
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -179,7 +179,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: assertoor_darwin_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: assertoor_darwin_amd64
@@ -188,13 +188,13 @@ jobs:
     name: Build macos/arm64 binary
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -213,7 +213,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: assertoor_darwin_arm64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: assertoor_darwin_arm64
@@ -224,7 +224,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
 
@@ -234,16 +234,16 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     # download build artifacts
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
         name: assertoor_linux_amd64
         path: ./bin
@@ -272,7 +272,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -281,18 +281,18 @@ jobs:
 
     # prepare docker
     - name: Set up Docker QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     # download build artifacts
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
         name: assertoor_linux_arm64
         path: ./bin
@@ -321,7 +321,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -330,9 +330,9 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -356,7 +356,7 @@ jobs:
       matrix:
         tag: ${{ fromJSON(inputs.additional_tags) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -365,9 +365,9 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -9,11 +9,11 @@ jobs:
     name: Run code checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
     
@@ -33,7 +33,7 @@ jobs:
 
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.59.1

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout base code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         path: code
     - name: Generate wiki from docs
@@ -83,11 +83,11 @@ jobs:
     steps:
     # download build artifacts
     - name: "Download build artifacts"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
 
     # (re)create snapshot binary release
     - name: Update snapshot tag & remove previous snapshot release
-      uses: actions/github-script@v3
+      uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -134,7 +134,7 @@ jobs:
             console.log(e)
           }
     - name: Create snapshot release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       id: create_release
       with:
         draft: false
@@ -164,7 +164,7 @@ jobs:
         cd assertoor_windows_amd64
         zip -r -q ../assertoor_snapshot_windows_amd64.zip .
     - name: "Upload snapshot release artifact: assertoor_snapshot_windows_amd64.zip"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_snapshot_windows_amd64.zip
@@ -178,7 +178,7 @@ jobs:
         cd assertoor_linux_amd64
         tar -czf ../assertoor_snapshot_linux_amd64.tar.gz .
     - name: "Upload snapshot release artifact: assertoor_snapshot_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_snapshot_linux_amd64.tar.gz
@@ -192,7 +192,7 @@ jobs:
         cd assertoor_linux_arm64
         tar -czf ../assertoor_snapshot_linux_arm64.tar.gz .
     - name: "Upload snapshot release artifact: assertoor_snapshot_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_snapshot_linux_arm64.tar.gz
@@ -206,7 +206,7 @@ jobs:
         cd assertoor_darwin_amd64
         tar -czf ../assertoor_snapshot_darwin_amd64.tar.gz .
     - name: "Upload snapshot release artifact: assertoor_snapshot_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_snapshot_darwin_amd64.tar.gz
@@ -220,7 +220,7 @@ jobs:
         cd assertoor_darwin_arm64
         tar -czf ../assertoor_snapshot_darwin_arm64.tar.gz .
     - name: "Upload snapshot release artifact: assertoor_snapshot_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [build_binaries]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 100
         ref: ${{ github.sha }}
@@ -52,11 +52,11 @@ jobs:
 
     # download build artifacts
     - name: "Download build artifacts"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
 
     # create draft release
     - name: Create latest release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       id: create_release
       with:
         draft: true
@@ -85,7 +85,7 @@ jobs:
         cd assertoor_windows_amd64
         zip -r -q ../assertoor_${{ inputs.version }}_windows_amd64.zip .
     - name: "Upload release artifact: assertoor_${{ inputs.version }}_windows_amd64.zip"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_${{ inputs.version }}_windows_amd64.zip
@@ -99,7 +99,7 @@ jobs:
         cd assertoor_linux_amd64
         tar -czf ../assertoor_${{ inputs.version }}_linux_amd64.tar.gz .
     - name: "Upload release artifact: assertoor_${{ inputs.version }}_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_${{ inputs.version }}_linux_amd64.tar.gz
@@ -113,7 +113,7 @@ jobs:
         cd assertoor_linux_arm64
         tar -czf ../assertoor_${{ inputs.version }}_linux_arm64.tar.gz .
     - name: "Upload release artifact: assertoor_${{ inputs.version }}_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_${{ inputs.version }}_linux_arm64.tar.gz
@@ -127,7 +127,7 @@ jobs:
         cd assertoor_darwin_amd64
         tar -czf ../assertoor_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Upload release artifact: assertoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_${{ inputs.version }}_darwin_amd64.tar.gz
@@ -141,7 +141,7 @@ jobs:
         cd assertoor_darwin_arm64
         tar -czf ../assertoor_${{ inputs.version }}_darwin_arm64.tar.gz .
     - name: "Upload release artifact: assertoor_${{ inputs.version }}_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./assertoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.