### PR TITLE
allow parallel test execution via `skip_queue` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Assertoor is a robust and versatile tool designed for comprehensive testing of t
 ## Documentation and Examples
 
 Refer to our [documentation](https://github.com/ethpandaops/assertoor/wiki) for installation, configuration, and usage guidelines. \
-Example tests are available [here](https://github.com/ethpandaops/assertoor/tree/master/example/tests).
+Example tests are available [here](https://github.com/ethpandaops/assertoor/tree/master/playbooks).
 
 ## Contributing
 

--- a/pkg/coordinator/clients/execution/clientlogic.go
+++ b/pkg/coordinator/clients/execution/clientlogic.go
@@ -65,7 +65,7 @@ func (client *Client) checkClient() error {
 	client.versionStr = nodeVersion
 	client.parseClientVersion(nodeVersion)
 
-	// get & comare chain specs
+	// get & compare chain specs
 	specs, err := client.rpcClient.GetChainSpec(ctx)
 	if err != nil {
 		return fmt.Errorf("error while fetching specs: %v", err)

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -292,7 +292,7 @@ func (c *Coordinator) DeleteTestRun(runID uint64) error {
 	return err
 }
 
-func (c *Coordinator) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool, skipQueue bool) (types.TestRunner, error) {
+func (c *Coordinator) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate, skipQueue bool) (types.TestRunner, error) {
 	return c.runner.ScheduleTest(descriptor, configOverrides, allowDuplicate, skipQueue)
 }
 

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -191,7 +191,10 @@ func (c *Coordinator) Run(ctx context.Context) error {
 	// start per epoch GC routine
 	go c.runEpochGC(ctx)
 
-	// run tests
+	// start off queue test execution loop
+	go c.runner.RunOffQueueTestExecutionLoop(ctx)
+
+	// run test execution loop for queued tests
 	c.runner.RunTestExecutionLoop(ctx, c.Config.Coordinator.MaxConcurrentTests)
 
 	return nil
@@ -289,8 +292,8 @@ func (c *Coordinator) DeleteTestRun(runID uint64) error {
 	return err
 }
 
-func (c *Coordinator) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool) (types.TestRunner, error) {
-	return c.runner.ScheduleTest(descriptor, configOverrides, allowDuplicate)
+func (c *Coordinator) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool, skipQueue bool) (types.TestRunner, error) {
+	return c.runner.ScheduleTest(descriptor, configOverrides, allowDuplicate, skipQueue)
 }
 
 func (c *Coordinator) startMetrics() error {

--- a/pkg/coordinator/tasks/check_consensus_forks/README.md
+++ b/pkg/coordinator/tasks/check_consensus_forks/README.md
@@ -13,7 +13,7 @@ The `check_consensus_forks` task is designed to check for forks in the consensus
   The distance is measured by the number of blocks between the heads of the forked chains.
 
 - **`maxForkCount`**:\
-  The maximum number of forks that are acceptable. If the number of forks exceeds this limit, the task will coplete with a failure result.
+  The maximum number of forks that are acceptable. If the number of forks exceeds this limit, the task will complete with a failure result.
 
 ### Defaults
 

--- a/pkg/coordinator/tasks/generate_eoa_transactions/task.go
+++ b/pkg/coordinator/tasks/generate_eoa_transactions/task.go
@@ -249,7 +249,7 @@ func (t *Task) Execute(ctx context.Context) error {
 		t.logger.Infof("set task result to failed, %v transactions reverted unexpectedly (FailOnReject)", revertCount)
 		t.ctx.SetResult(types.TaskResultFailure)
 	case totalCount == 0:
-		t.logger.Infof("set task result to failed, no tansactions sent")
+		t.logger.Infof("set task result to failed, no transactions sent")
 		t.ctx.SetResult(types.TaskResultFailure)
 	}
 

--- a/pkg/coordinator/testrunner.go
+++ b/pkg/coordinator/testrunner.go
@@ -16,24 +16,24 @@ type TestRunner struct {
 	coordinator types.Coordinator
 
 	runIDCounter       uint64
-	lastExecutedRunID  uint64
 	testSchedulerMutex sync.Mutex
 
-	testRunMap           map[uint64]types.Test
-	testQueue            []types.TestRunner
-	testRegistryMutex    sync.RWMutex
-	testNotificationChan chan bool
+	testRunMap               map[uint64]types.Test
+	testQueue                []types.TestRunner
+	testRegistryMutex        sync.RWMutex
+	queueNotificationChan    chan bool
+	offQueueNotificationChan chan types.TestRunner
 }
 
 func NewTestRunner(coordinator types.Coordinator, lastRunID uint64) *TestRunner {
 	return &TestRunner{
-		coordinator:       coordinator,
-		runIDCounter:      lastRunID,
-		lastExecutedRunID: lastRunID,
+		coordinator:  coordinator,
+		runIDCounter: lastRunID,
 
-		testRunMap:           map[uint64]types.Test{},
-		testQueue:            []types.TestRunner{},
-		testNotificationChan: make(chan bool, 1),
+		testRunMap:               map[uint64]types.Test{},
+		testQueue:                []types.TestRunner{},
+		queueNotificationChan:    make(chan bool, 1),
+		offQueueNotificationChan: make(chan types.TestRunner, 10),
 	}
 }
 
@@ -76,25 +76,29 @@ func (c *TestRunner) RemoveTestFromQueue(runID uint64) bool {
 	return false
 }
 
-func (c *TestRunner) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool) (types.TestRunner, error) {
+func (c *TestRunner) ScheduleTest(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool, skipQueue bool) (types.TestRunner, error) {
 	if descriptor.Err() != nil {
 		return nil, fmt.Errorf("cannot create test from failed test descriptor: %w", descriptor.Err())
 	}
 
-	testRef, err := c.createTestRun(descriptor, configOverrides, allowDuplicate)
+	testRef, err := c.createTestRun(descriptor, configOverrides, allowDuplicate, skipQueue)
 	if err != nil {
 		return nil, err
 	}
 
-	select {
-	case c.testNotificationChan <- true:
-	default:
+	if skipQueue {
+		c.offQueueNotificationChan <- testRef
+	} else {
+		select {
+		case c.queueNotificationChan <- true:
+		default:
+		}
 	}
 
 	return testRef, nil
 }
 
-func (c *TestRunner) createTestRun(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool) (types.TestRunner, error) {
+func (c *TestRunner) createTestRun(descriptor types.TestDescriptor, configOverrides map[string]any, allowDuplicate bool, skipQueue bool) (types.TestRunner, error) {
 	c.testSchedulerMutex.Lock()
 	defer c.testSchedulerMutex.Unlock()
 
@@ -115,7 +119,9 @@ func (c *TestRunner) createTestRun(descriptor types.TestDescriptor, configOverri
 	}
 
 	c.testRegistryMutex.Lock()
-	c.testQueue = append(c.testQueue, testRef)
+	if !skipQueue {
+		c.testQueue = append(c.testQueue, testRef)
+	}
 	c.testRunMap[runID] = testRef
 	c.testRegistryMutex.Unlock()
 
@@ -164,7 +170,7 @@ runLoop:
 			select {
 			case <-ctx.Done():
 				break runLoop
-			case <-c.testNotificationChan:
+			case <-c.queueNotificationChan:
 			case <-time.After(60 * time.Second):
 			}
 		}
@@ -173,9 +179,18 @@ runLoop:
 	waitGroup.Wait()
 }
 
-func (c *TestRunner) runTest(ctx context.Context, testRef types.TestRunner) {
-	c.lastExecutedRunID = testRef.RunID()
+func (c *TestRunner) RunOffQueueTestExecutionLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case testRef := <-c.offQueueNotificationChan:
+			go c.runTest(ctx, testRef)
+		}
+	}
+}
 
+func (c *TestRunner) runTest(ctx context.Context, testRef types.TestRunner) {
 	if err := testRef.Validate(); err != nil {
 		testRef.Logger().Errorf("test validation failed: %v", err)
 		return
@@ -195,9 +210,10 @@ func (c *TestRunner) RunTestScheduler(ctx context.Context) {
 
 	// startup scheduler
 	for _, testDescr := range c.getStartupTests() {
-		_, err := c.ScheduleTest(testDescr, nil, false)
+		testConfig := testDescr.Config()
+		_, err := c.ScheduleTest(testDescr, nil, false, testConfig.Schedule.SkipQueue)
 		if err != nil {
-			c.coordinator.Logger().Errorf("could not schedule startup test execution for %v (%v): %v", testDescr.ID(), testDescr.Config().Name, err)
+			c.coordinator.Logger().Errorf("could not schedule startup test execution for %v (%v): %v", testDescr.ID(), testConfig.Name, err)
 		}
 	}
 
@@ -217,9 +233,10 @@ func (c *TestRunner) RunTestScheduler(ctx context.Context) {
 		}
 
 		for _, testDescr := range c.getCronTests(cronTime) {
-			_, err := c.ScheduleTest(testDescr, nil, false)
+			testConfig := testDescr.Config()
+			_, err := c.ScheduleTest(testDescr, nil, false, testConfig.Schedule.SkipQueue)
 			if err != nil {
-				c.coordinator.Logger().Errorf("could not schedule cron test execution for %v (%v): %v", testDescr.ID(), testDescr.Config().Name, err)
+				c.coordinator.Logger().Errorf("could not schedule cron test execution for %v (%v): %v", testDescr.ID(), testConfig.Name, err)
 			}
 		}
 	}

--- a/pkg/coordinator/types/coordinator.go
+++ b/pkg/coordinator/types/coordinator.go
@@ -24,7 +24,7 @@ type Coordinator interface {
 	GetTestByRunID(runID uint64) Test
 	GetTestQueue() []Test
 	GetTestHistory(testID string, firstRunID uint64, offset uint64, limit uint64) ([]Test, int)
-	ScheduleTest(descriptor TestDescriptor, configOverrides map[string]any, allowDuplicate bool) (TestRunner, error)
+	ScheduleTest(descriptor TestDescriptor, configOverrides map[string]any, allowDuplicate bool, skipQueue bool) (TestRunner, error)
 	DeleteTestRun(runID uint64) error
 }
 

--- a/pkg/coordinator/types/test.go
+++ b/pkg/coordinator/types/test.go
@@ -61,8 +61,9 @@ type ExternalTestConfig struct {
 }
 
 type TestSchedule struct {
-	Startup bool     `yaml:"startup" json:"startup"`
-	Cron    []string `yaml:"cron" json:"cron"`
+	Startup   bool     `yaml:"startup" json:"startup"`
+	Cron      []string `yaml:"cron" json:"cron"`
+	SkipQueue bool     `yaml:"skipQueue" json:"skipQueue"`
 }
 
 type TestDescriptor interface {

--- a/pkg/coordinator/web/api/docs/docs.go
+++ b/pkg/coordinator/web/api/docs/docs.go
@@ -1104,6 +1104,9 @@ const docTemplate = `{
                     "type": "object",
                     "additionalProperties": {}
                 },
+                "skip_queue": {
+                    "type": "boolean"
+                },
                 "test_id": {
                     "type": "string"
                 }
@@ -1271,6 +1274,9 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "skipQueue": {
+                    "type": "boolean"
                 },
                 "startup": {
                     "type": "boolean"

--- a/pkg/coordinator/web/api/docs/swagger.json
+++ b/pkg/coordinator/web/api/docs/swagger.json
@@ -1096,6 +1096,9 @@
                     "type": "object",
                     "additionalProperties": {}
                 },
+                "skip_queue": {
+                    "type": "boolean"
+                },
                 "test_id": {
                     "type": "string"
                 }
@@ -1263,6 +1266,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "skipQueue": {
+                    "type": "boolean"
                 },
                 "startup": {
                     "type": "boolean"

--- a/pkg/coordinator/web/api/docs/swagger.yaml
+++ b/pkg/coordinator/web/api/docs/swagger.yaml
@@ -222,6 +222,8 @@ definitions:
       config:
         additionalProperties: {}
         type: object
+      skip_queue:
+        type: boolean
       test_id:
         type: string
     type: object
@@ -333,6 +335,8 @@ definitions:
         items:
           type: string
         type: array
+      skipQueue:
+        type: boolean
       startup:
         type: boolean
     type: object

--- a/pkg/coordinator/web/api/post_test_run_api.go
+++ b/pkg/coordinator/web/api/post_test_run_api.go
@@ -13,6 +13,7 @@ type PostTestRunsScheduleRequest struct {
 	TestID         string         `json:"test_id"`
 	Config         map[string]any `json:"config"`
 	AllowDuplicate bool           `json:"allow_duplicate"`
+	SkipQueue      bool           `json:"skip_queue"`
 }
 
 type PostTestRunsScheduleResponse struct {
@@ -77,7 +78,7 @@ func (ah *APIHandler) PostTestRunsSchedule(w http.ResponseWriter, r *http.Reques
 	}
 
 	// create test run
-	testInstance, err := ah.coordinator.ScheduleTest(testDescriptor, req.Config, req.AllowDuplicate)
+	testInstance, err := ah.coordinator.ScheduleTest(testDescriptor, req.Config, req.AllowDuplicate, req.SkipQueue)
 	if err != nil {
 		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("failed creating test: %v", err), http.StatusInternalServerError)
 		return

--- a/pkg/coordinator/web/templates/registry/registry.html
+++ b/pkg/coordinator/web/templates/registry/registry.html
@@ -213,6 +213,16 @@
                 <textarea class="form-control" id="startTestConfigOverrides" rows="3" style="width:100%;height:400px;"></textarea>
               </div>
             </div>
+            <div class="row mt-3">
+              <div class="col-12">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="skipQueueCheckbox">
+                  <label class="form-check-label" for="skipQueueCheckbox">
+                    Skip Queue (Start immediately)
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -344,7 +354,8 @@
               async: false,
               data: JSON.stringify({
                 test_id: $("#startTestTestID").text(),
-                config: configJson
+                config: configJson,
+                skip_queue: $("#skipQueueCheckbox").prop("checked")
               }),
               success: resolve,
               error: reject

--- a/pkg/coordinator/web/templates/test/test.html
+++ b/pkg/coordinator/web/templates/test/test.html
@@ -64,6 +64,16 @@
                 <textarea class="form-control" id="testConfigOverrides" rows="3" style="width:100%;height:400px;"></textarea>
               </div>
             </div>
+            <div class="row mt-3">
+              <div class="col-12">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="skipQueueCheckbox">
+                  <label class="form-check-label" for="skipQueueCheckbox">
+                    Skip Queue (Start immediately)
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -114,7 +124,8 @@ $(document).ready(function() {
         async: false,
         data: JSON.stringify({
           test_id: "{{ .ID }}",
-          config: configJson
+          config: configJson,
+          skip_queue: $("#skipQueueCheckbox").prop("checked")
         }),
         success: resolve,
         error: reject

--- a/playbooks/pectra-dev/kurtosis/eip7702-txpool-invalidation.yaml
+++ b/playbooks/pectra-dev/kurtosis/eip7702-txpool-invalidation.yaml
@@ -138,7 +138,7 @@ tasks:
   config:
     tasks:
 
-    # delpoy eip7701 test contract & test delegate
+    # deploy eip7701 test contract & test delegate
     - name: run_tasks_concurrent
       title: "Prepare eip7702 invalidation test contracts"
       config:


### PR DESCRIPTION
This PR adds support for parallel test execution by skipping the queue for test runs on request.
To activate, tests need to set `schedule.skipQueue` to true, or need to be stated with the `skip_queue` flag set to true in the PostTestRunsSchedule api.