### PR TITLE
feat: add WebUI support for custom YAML playbook uploads

### DIFF
--- a/cgc-test.yaml
+++ b/cgc-test.yaml
@@ -1,0 +1,18 @@
+id: cgc_validation_test
+name: "CGC Validation Test"
+timeout: 5m
+config:
+  description: "Comprehensive test to validate CGC (Custody Group Count) values in consensus layer client ENR records"
+  
+tasks:
+  - name: "check_consensus_cgc"
+    description: "Basic CGC check for all consensus clients"
+    timeout: 2m
+    config:
+      clientPattern: ".*"
+      pollInterval: 10s
+      expectedNonValidating: 0x04
+      expectedValidating: 0x08
+      minClientCount: 1
+      failOnCheckMiss: true
+      resultVar: "detected_cgc_value"

--- a/pkg/coordinator/web/api/post_tests_register_upload_api.go
+++ b/pkg/coordinator/web/api/post_tests_register_upload_api.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ethpandaops/assertoor/pkg/coordinator/helper"
+	"github.com/ethpandaops/assertoor/pkg/coordinator/types"
+	"gopkg.in/yaml.v3"
+)
+
+type PostTestsRegisterUploadResponse struct {
+	TestID string         `json:"test_id"`
+	Name   string         `json:"name"`
+	Config map[string]any `json:"config"`
+}
+
+// PostTestsRegisterUpload godoc
+// @Id postTestsRegisterUpload
+// @Summary Register new test via uploaded YAML file
+// @Tags Test
+// @Description Upload a YAML test configuration file and register the test. Returns the test id and name of the added test.
+// @Produce json
+// @Accept multipart/form-data
+// @Param playbook formData file true "YAML test configuration file"
+// @Param name formData string false "Custom test name override"
+// @Param timeout formData integer false "Custom timeout in seconds"
+// @Param config formData string false "Custom config overrides as YAML"
+// @Param configVars formData string false "Custom config variables as YAML"
+// @Success 200 {object} Response{data=PostTestsRegisterUploadResponse} "Success"
+// @Failure 400 {object} Response "Failure"
+// @Failure 500 {object} Response "Server Error"
+// @Router /api/v1/tests/register_upload [post]
+func (ah *APIHandler) PostTestsRegisterUpload(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+
+	// Parse multipart form
+	err := r.ParseMultipartForm(10 << 20) // 10 MB max
+	if err != nil {
+		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error parsing multipart form: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Get uploaded file
+	file, fileHeader, err := r.FormFile("playbook")
+	if err != nil {
+		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error retrieving uploaded file: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// Read file content
+	fileContent, err := io.ReadAll(file)
+	if err != nil {
+		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error reading uploaded file: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Parse YAML test configuration
+	var testConfig types.TestConfig
+	err = yaml.Unmarshal(fileContent, &testConfig)
+	if err != nil {
+		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error parsing YAML test configuration: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Validate required fields
+	if testConfig.ID == "" {
+		ah.sendErrorResponse(w, r.URL.String(), "test id missing or empty in uploaded file", http.StatusBadRequest)
+		return
+	}
+
+	if testConfig.Name == "" {
+		ah.sendErrorResponse(w, r.URL.String(), "test name missing or empty in uploaded file", http.StatusBadRequest)
+		return
+	}
+
+	if len(testConfig.Tasks) == 0 {
+		ah.sendErrorResponse(w, r.URL.String(), "test must have 1 or more tasks", http.StatusBadRequest)
+		return
+	}
+
+	// Apply form overrides
+	customName := r.FormValue("name")
+	if customName != "" {
+		testConfig.Name = customName
+	}
+
+	customTimeout := r.FormValue("timeout")
+	if customTimeout != "" {
+		timeoutDuration, err := time.ParseDuration(customTimeout + "s")
+		if err != nil {
+			ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("invalid timeout format: %v", err), http.StatusBadRequest)
+			return
+		}
+		testConfig.Timeout = helper.Duration{Duration: timeoutDuration}
+	}
+
+	// Parse custom config overrides
+	customConfig := r.FormValue("config")
+	if customConfig != "" {
+		var configOverrides map[string]interface{}
+		err = yaml.Unmarshal([]byte(customConfig), &configOverrides)
+		if err != nil {
+			ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error parsing config overrides: %v", err), http.StatusBadRequest)
+			return
+		}
+		// Merge with existing config
+		if testConfig.Config == nil {
+			testConfig.Config = make(map[string]interface{})
+		}
+		for key, value := range configOverrides {
+			testConfig.Config[key] = value
+		}
+	}
+
+	// Parse custom config variables
+	customConfigVars := r.FormValue("configVars")
+	if customConfigVars != "" {
+		var configVars map[string]string
+		err = yaml.Unmarshal([]byte(customConfigVars), &configVars)
+		if err != nil {
+			ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("error parsing config variables: %v", err), http.StatusBadRequest)
+			return
+		}
+		// Merge with existing config vars
+		if testConfig.ConfigVars == nil {
+			testConfig.ConfigVars = make(map[string]string)
+		}
+		for key, value := range configVars {
+			testConfig.ConfigVars[key] = value
+		}
+	}
+
+	// Add metadata about the upload
+	if testConfig.Config == nil {
+		testConfig.Config = make(map[string]interface{})
+	}
+	testConfig.Config["_uploadedFile"] = fileHeader.Filename
+	testConfig.Config["_uploadedAt"] = time.Now().UTC().Format(time.RFC3339)
+
+	// Register the test
+	testDescriptor, err := ah.coordinator.TestRegistry().AddLocalTest(&testConfig)
+	if err != nil {
+		ah.sendErrorResponse(w, r.URL.String(), fmt.Sprintf("failed adding test: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	ah.sendOKResponse(w, r.URL.String(), &PostTestsRegisterUploadResponse{
+		TestID: testDescriptor.ID(),
+		Name:   testDescriptor.Config().Name,
+		Config: testDescriptor.Config().Config,
+	})
+}

--- a/pkg/coordinator/web/server.go
+++ b/pkg/coordinator/web/server.go
@@ -90,6 +90,7 @@ func (ws *Server) ConfigureRoutes(frontendConfig *types.FrontendConfig, apiConfi
 		if !securityTrimmed {
 			ws.router.HandleFunc("/api/v1/tests/register", apiHandler.PostTestsRegister).Methods("POST")
 			ws.router.HandleFunc("/api/v1/tests/register_external", apiHandler.PostTestsRegisterExternal).Methods("POST")
+			ws.router.HandleFunc("/api/v1/tests/register_upload", apiHandler.PostTestsRegisterUpload).Methods("POST")
 			ws.router.HandleFunc("/api/v1/tests/delete", apiHandler.PostTestsDelete).Methods("POST")
 			ws.router.HandleFunc("/api/v1/test_run", apiHandler.PostTestRunsSchedule).Methods("POST") // legacy
 			ws.router.HandleFunc("/api/v1/test_runs/schedule", apiHandler.PostTestRunsSchedule).Methods("POST")

--- a/pkg/coordinator/web/templates/sidebar/sidebar.html
+++ b/pkg/coordinator/web/templates/sidebar/sidebar.html
@@ -64,20 +64,52 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body container-fluid">
-          <div class="row">
-            <div class="col-4">
-              Playbook URL:
-            </div>
-            <div class="col-8">
-              <input type="text" class="form-control" id="registerTestFile" placeholder="https://.../test.yaml">
+          <!-- Registration method selection -->
+          <div class="row mb-3">
+            <div class="col-12">
+              <div class="btn-group w-100" role="group" aria-label="Registration method">
+                <input type="radio" class="btn-check" name="registrationMethod" id="urlMethod" autocomplete="off" checked>
+                <label class="btn btn-outline-primary" for="urlMethod">From URL</label>
+                
+                <input type="radio" class="btn-check" name="registrationMethod" id="uploadMethod" autocomplete="off">
+                <label class="btn btn-outline-primary" for="uploadMethod">Upload File</label>
+              </div>
             </div>
           </div>
-          <div class="row">
+          
+          <!-- URL registration fields -->
+          <div id="urlRegistrationFields">
+            <div class="row mb-2">
+              <div class="col-4">
+                Playbook URL:
+              </div>
+              <div class="col-8">
+                <input type="text" class="form-control" id="registerTestFile" placeholder="https://.../test.yaml">
+              </div>
+            </div>
+          </div>
+          
+          <!-- File upload registration fields -->
+          <div id="uploadRegistrationFields" style="display: none;">
+            <div class="row mb-2">
+              <div class="col-4">
+                Playbook File:
+              </div>
+              <div class="col-8">
+                <input type="file" class="form-control" id="registerTestFileUpload" accept=".yaml,.yml">
+                <div class="form-text">Select a YAML test configuration file</div>
+              </div>
+            </div>
+          </div>
+          
+          <!-- Common fields -->
+          <div class="row mb-2">
             <div class="col-4">
               Custom Name:
             </div>
             <div class="col-8">
               <input type="text" class="form-control" id="registerTestName">
+              <div class="form-text">Optional: Override the test name from the file</div>
             </div>
           </div>
           <div class="row">
@@ -86,6 +118,7 @@
             </div>
             <div class="col-12 ">
               <textarea class="form-control" id="registerTestConfig" rows="3" style="width:100%;height:400px;"></textarea>
+              <div class="form-text">Optional: YAML configuration overrides</div>
             </div>
           </div>
         </div>
@@ -104,53 +137,118 @@
       window.editor = editor;
       resetConfigOverrides();
       $("#registerTestButton").on("click", registerTest);
+      
+      // Handle registration method toggle
+      $('input[name="registrationMethod"]').on('change', function() {
+        if ($("#urlMethod").is(':checked')) {
+          $("#urlRegistrationFields").show();
+          $("#uploadRegistrationFields").hide();
+        } else {
+          $("#urlRegistrationFields").hide();
+          $("#uploadRegistrationFields").show();
+        }
+        // Clear inputs when switching methods
+        $("#registerTestFile").val("");
+        $("#registerTestFileUpload").val("");
+      });
     
       function resetConfigOverrides() {
         editor.setValue("", -1);
       }
     
       function registerTest() {
+        var configYaml = editor.getValue();
         var configJson;
-        try {
-          var configYaml = editor.getValue();
-          configJson = YAML.parse(configYaml);
-        } catch(ex) {
-          alert("invalid config yaml: " + ex.toString());
-          return;
+        
+        // Only parse config if it's not empty
+        if (configYaml.trim()) {
+          try {
+            configJson = YAML.parse(configYaml);
+          } catch(ex) {
+            alert("invalid config yaml: " + ex.toString());
+            return;
+          }
         }
 
-        var testFile = $("#registerTestFile").val();
-        if(!testFile) {
-          alert("playbook link is required");
-          return;
-        }
-    
-        var reqPromise = new Promise(function(resolve, reject) {
-          $.ajax({
-            type: "POST",
-            url: "/api/v1/tests/register_external",
-            dataType: "json",
-            async: false,
-            data: JSON.stringify({
-              file: testFile,
-              name: $("#registerTestName").val() || "",
-              config: configJson
-            }),
-            success: resolve,
-            error: reject
-          });
-        });
-    
-        reqPromise.then(function(res) {
-          if(!res || res.status !== "OK") {
-            throw res.status;
+        if ($("#urlMethod").is(':checked')) {
+          // URL-based registration
+          var testFile = $("#registerTestFile").val();
+          if(!testFile) {
+            alert("playbook link is required");
+            return;
           }
-          location.reload();
-        }, function(rsp) {
-          throw rsp.responseJSON ? rsp.responseJSON.status : rsp.statusText;
-        }).catch(function(err) {
-          alert("Could not register test: " + err.toString());
-        });
+          
+          var reqPromise = new Promise(function(resolve, reject) {
+            $.ajax({
+              type: "POST",
+              url: "/api/v1/tests/register_external",
+              dataType: "json",
+              async: false,
+              data: JSON.stringify({
+                file: testFile,
+                name: $("#registerTestName").val() || "",
+                config: configJson
+              }),
+              success: resolve,
+              error: reject
+            });
+          });
+          
+          reqPromise.then(function(res) {
+            if(!res || res.status !== "OK") {
+              throw res.status;
+            }
+            location.reload();
+          }, function(rsp) {
+            throw rsp.responseJSON ? rsp.responseJSON.status : rsp.statusText;
+          }).catch(function(err) {
+            alert("Could not register test: " + err.toString());
+          });
+        } else {
+          // File upload registration
+          var fileInput = $("#registerTestFileUpload")[0];
+          if(!fileInput.files || fileInput.files.length === 0) {
+            alert("please select a playbook file to upload");
+            return;
+          }
+          
+          var formData = new FormData();
+          formData.append('playbook', fileInput.files[0]);
+          
+          var customName = $("#registerTestName").val();
+          if (customName) {
+            formData.append('name', customName);
+          }
+          
+          if (configYaml.trim()) {
+            formData.append('config', configYaml);
+          }
+          
+          var reqPromise = new Promise(function(resolve, reject) {
+            $.ajax({
+              type: "POST",
+              url: "/api/v1/tests/register_upload",
+              dataType: "json",
+              async: false,
+              data: formData,
+              processData: false,
+              contentType: false,
+              success: resolve,
+              error: reject
+            });
+          });
+          
+          reqPromise.then(function(res) {
+            if(!res || res.status !== "OK") {
+              throw res.status;
+            }
+            location.reload();
+          }, function(rsp) {
+            throw rsp.responseJSON ? rsp.responseJSON.status : rsp.statusText;
+          }).catch(function(err) {
+            alert("Could not register test: " + err.toString());
+          });
+        }
       }
     
     });


### PR DESCRIPTION
## Summary
- Add new file upload functionality to the WebUI test registration modal
- Introduce `/api/v1/tests/register_upload` API endpoint for multipart form uploads
- Maintain backward compatibility with existing URL-based registration

## Changes Made
- **Backend**: New API endpoint `/api/v1/tests/register_upload` that accepts multipart form data
- **Frontend**: Enhanced register test modal with radio button toggle between URL and file upload methods
- **UI/UX**: Added form guidance text and proper file input validation
- **Validation**: Comprehensive YAML parsing and file size limits (10MB max)

## Features
1. **Dual Registration Methods**: Users can choose between URL-based or file upload registration
2. **Custom Overrides**: Support for custom test names and configuration overrides
3. **File Metadata**: Uploaded file information is preserved in test configuration
4. **Error Handling**: Proper validation and user-friendly error messages
5. **File Type Filtering**: Only accepts `.yaml` and `.yml` files

## UI Changes
The register test modal now includes:
- Radio button toggle for "From URL" vs "Upload File"
- File input with `.yaml/.yml` file type restrictions
- Enhanced form guidance text
- Dynamic field visibility based on selected method

## API Changes
- **New endpoint**: `POST /api/v1/tests/register_upload`
- **Content-Type**: `multipart/form-data`
- **Parameters**: 
  - `playbook` (file): YAML test configuration file
  - `name` (optional): Custom test name override
  - `config` (optional): YAML configuration overrides
  - `configVars` (optional): YAML configuration variables

## Test plan
- [x] Build successfully compiles
- [x] WebUI loads with new upload interface
- [x] File upload validation works
- [x] API endpoint handles multipart form data
- [x] Test registration via upload functions
- [x] Backward compatibility with URL method maintained
- [x] Error handling works correctly

## Example
Included `cgc-test.yaml` demonstrates the new upload functionality for CGC validation testing.

🤖 Generated with [Claude Code](https://claude.ai/code)