### PR TITLE
fix: panic for nil pointer dereference runRangeCheck

### DIFF
--- a/pkg/coordinator/tasks/check_consensus_slot_range/task.go
+++ b/pkg/coordinator/tasks/check_consensus_slot_range/task.go
@@ -100,10 +100,12 @@ func (t *Task) Execute(ctx context.Context) error {
 func (t *Task) runRangeCheck() (checkResult, isLower bool) {
 	consensusPool := t.ctx.Scheduler.GetServices().ClientPool().GetConsensusPool()
 	genesis := consensusPool.GetBlockCache().GetGenesis()
+
 	if genesis == nil {
 		t.logger.Errorf("genesis data not available")
 		return false, true
 	}
+
 	if genesis.GenesisTime.Compare(time.Now()) >= 0 {
 		return false, true
 	}

--- a/pkg/coordinator/tasks/check_consensus_slot_range/task.go
+++ b/pkg/coordinator/tasks/check_consensus_slot_range/task.go
@@ -99,7 +99,12 @@ func (t *Task) Execute(ctx context.Context) error {
 
 func (t *Task) runRangeCheck() (checkResult, isLower bool) {
 	consensusPool := t.ctx.Scheduler.GetServices().ClientPool().GetConsensusPool()
-	if consensusPool.GetBlockCache().GetGenesis().GenesisTime.Compare(time.Now()) >= 0 {
+	genesis := consensusPool.GetBlockCache().GetGenesis()
+	if genesis == nil {
+		t.logger.Errorf("genesis data not available")
+		return false, true
+	}
+	if genesis.GenesisTime.Compare(time.Now()) >= 0 {
 		return false, true
 	}
 
@@ -109,7 +114,7 @@ func (t *Task) runRangeCheck() (checkResult, isLower bool) {
 		return false, true
 	}
 
-	t.ctx.Outputs.SetVar("genesisTime", consensusPool.GetBlockCache().GetGenesis().GenesisTime.Unix())
+	t.ctx.Outputs.SetVar("genesisTime", genesis.GenesisTime.Unix())
 	t.ctx.Outputs.SetVar("currentSlot", currentSlot.Number())
 	t.ctx.Outputs.SetVar("currentEpoch", currentEpoch.Number())
 


### PR DESCRIPTION
fixing this panic:
```sh
time="2025-07-11T15:07:14Z" level=error msg="task execution panic: runtime error: invalid memory address or nil pointer dereference, stack: goroutine 254 [running]:\nruntime/debug.Stack()\n\t/opt/hostedtoolcache/go/1.24.4/x64/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/ethpandaops/assertoor/pkg/coordinator/scheduler.(*TaskScheduler).ExecuteTask.func6()\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/scheduler/task_execution.go:143 +0xd2\npanic({0x1388940?, 0x2526620?})\n\t/opt/hostedtoolcache/go/1.24.4/x64/src/runtime/panic.go:792 +0x132\ngithub.com/ethpandaops/assertoor/pkg/coordinator/tasks/check_consensus_slot_range.(*Task).runRangeCheck(0xc00158e370)\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/tasks/check_consensus_slot_range/task.go:102 +0x59\ngithub.com/ethpandaops/assertoor/pkg/coordinator/tasks/check_consensus_slot_range.(*Task).Execute(0xc00158e370, {0x1affe30, 0xc00158e500})\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/tasks/check_consensus_slot_range/task.go:80 +0xf3\ngithub.com/ethpandaops/assertoor/pkg/coordinator/scheduler.(*TaskScheduler).ExecuteTask(0xc001377ba0, {0x1affea0, 0xc001585340}, 0x13d0440?, 0xc00155f550)\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/scheduler/task_execution.go:156 +0xa26\ngithub.com/ethpandaops/assertoor/pkg/coordinator/scheduler.(*TaskScheduler).RunTasks(0xc001377ba0, {0x1affe30, 0xc0000f26e0}, 0x68c61714000)\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/scheduler/scheduler.go:88 +0x225\ngithub.com/ethpandaops/assertoor/pkg/coordinator/test.(*Test).Run(0xc0000d2a50, {0x1affe30, 0xc0000f26e0})\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/test/test.go:211 +0x27f\ngithub.com/ethpandaops/assertoor/pkg/coordinator.(*TestRunner).runTest(0x0?, {0x1affe30, 0xc0000f26e0}, {0x1b0c7e0, 0xc0000d2a50})\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/testrunner.go:200 +0x106\ngithub.com/ethpandaops/assertoor/pkg/coordinator.(*TestRunner).RunTestExecutionLoop.func1({0x1b0c7e0?, 0xc0000d2a50?})\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/testrunner.go:159 +0x72\ncreated by github.com/ethpandaops/assertoor/pkg/coordinator.(*TestRunner).RunTestExecutionLoop in goroutine 35\n\t/home/runner/work/assertoor/assertoor/pkg/coordinator/testrunner.go:168 +0x2dc\n" RunID=1 TestID=w
```