### PR TITLE
Remove broken update_project_wiki job

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -35,47 +35,6 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
   
-  update_project_wiki:
-    name: Generate project documentation
-    needs: [check_source]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout base code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        path: code
-    - name: Generate wiki from docs
-      env:
-        WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
-      run: |
-        git clone https://$WIKI_TOKEN@github.com/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}.wiki.git ./wiki
-
-    - name: Generate wiki from docs
-      run: |
-        touch ./wiki.md
-
-        for filename in code/docs/*.md; do
-          while IFS= read -r line; do
-          if [[ "$line" =~ ^"#!!" ]]; then
-            bash -c "cd code && ${line:3}" >> ./wiki.md
-          else
-            echo "$line" >> ./wiki.md
-          fi
-          done <<< $(cat $filename)
-          echo "" >> ./wiki.md
-        done
-
-        cp ./wiki.md ./wiki/Home.md
-    - name: Push to wiki
-      env:
-        WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
-      run: |
-        cd wiki
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git diff-index --quiet HEAD || git commit -m "Add changes" && git push
-
   create_snapshot_release:
     name: Create snapshot release
     needs: [build_binaries]


### PR DESCRIPTION
## Summary

- Remove the `update_project_wiki` job from `build-master.yml`
- GitHub no longer supports PAT-based programmatic wiki push access, causing this job to fail on every master build with `fatal: could not read Password`

## Test plan

- [ ] Verify master build succeeds without the wiki job

🤖 Generated with [Claude Code](https://claude.com/claude-code)