### PR TITLE
fix nil pointer panic in check_consensus_sync_status

### DIFF
--- a/pkg/tasks/check_consensus_sync_status/task.go
+++ b/pkg/tasks/check_consensus_sync_status/task.go
@@ -215,11 +215,14 @@ func (t *Task) processClientCheck(client *clients.PoolClient, syncStatus *rpc.Sy
 
 func (t *Task) getClientInfo(client *clients.PoolClient, syncStatus *rpc.SyncStatus) *ClientInfo {
 	clientInfo := &ClientInfo{
-		Name:          client.Config.Name,
-		Synchronizing: syncStatus.IsSyncing,
-		Optimistic:    syncStatus.IsOptimistic,
-		SyncHead:      syncStatus.HeadSlot,
-		SyncDistance:  syncStatus.SyncDistance,
+		Name: client.Config.Name,
+	}
+
+	if syncStatus != nil {
+		clientInfo.Synchronizing = syncStatus.IsSyncing
+		clientInfo.Optimistic = syncStatus.IsOptimistic
+		clientInfo.SyncHead = syncStatus.HeadSlot
+		clientInfo.SyncDistance = syncStatus.SyncDistance
 	}
 
 	return clientInfo

--- a/pkg/tasks/check_consensus_sync_status/task.go
+++ b/pkg/tasks/check_consensus_sync_status/task.go
@@ -214,16 +214,21 @@ func (t *Task) processClientCheck(client *clients.PoolClient, syncStatus *rpc.Sy
 }
 
 func (t *Task) getClientInfo(client *clients.PoolClient, syncStatus *rpc.SyncStatus) *ClientInfo {
-	clientInfo := &ClientInfo{
-		Name: client.Config.Name,
+	if syncStatus == nil {
+		// RPC failed — return skeletal info without dereferencing.
+		return &ClientInfo{
+			Name:          client.Config.Name,
+			Synchronizing: true, // assume unhealthy when status is unknown
+			SyncHead:      0,
+			SyncDistance:  0,
+		}
 	}
 
-	if syncStatus != nil {
-		clientInfo.Synchronizing = syncStatus.IsSyncing
-		clientInfo.Optimistic = syncStatus.IsOptimistic
-		clientInfo.SyncHead = syncStatus.HeadSlot
-		clientInfo.SyncDistance = syncStatus.SyncDistance
+	return &ClientInfo{
+		Name:          client.Config.Name,
+		Synchronizing: syncStatus.IsSyncing,
+		Optimistic:    syncStatus.IsOptimistic,
+		SyncHead:      syncStatus.HeadSlot,
+		SyncDistance:  syncStatus.SyncDistance,
 	}
-
-	return clientInfo
 }


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference in `check_consensus_sync_status` when `GetNodeSyncStatus` returns an error
- When the RPC call fails (e.g. during network bootstrap before genesis), `syncStatus` is `nil`, but `getClientInfo` dereferences it unconditionally — causing a panic
- The analogous `check_execution_sync_status` task already has this nil guard; this applies the same pattern

### Panic trace from CI

```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 172 [running]:
github.com/ethpandaops/assertoor/pkg/tasks/check_consensus_sync_status.(*Task).getClientInfo(...)
    pkg/tasks/check_consensus_sync_status/task.go:219
github.com/ethpandaops/assertoor/pkg/tasks/check_consensus_sync_status.(*Task).processCheck(...)
    pkg/tasks/check_consensus_sync_status/task.go:142
```

Observed in Erigon CI glamsterdam Kurtosis tests: https://github.com/erigontech/erigon/actions/runs/24228480466/job/70734695754

## Test plan

- [ ] Verify `check_consensus_sync_status` no longer panics when a CL client is unreachable during startup
- [ ] Verify `ClientInfo` for failed clients has `Name` populated and sync fields zeroed