### PR TITLE
Show build commit hash in web UI footer

### DIFF
--- a/pkg/web/api/docs/docs.go
+++ b/pkg/web/api/docs/docs.go
@@ -1119,6 +1119,39 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/version": {
+            "get": {
+                "description": "Returns the build version (commit hash) and release of the running Assertoor binary.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "Get build version information",
+                "operationId": "getVersion",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web_api.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/web_api.GetVersionResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1606,6 +1639,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "web_api.GetVersionResponse": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/pkg/web/api/docs/swagger.json
+++ b/pkg/web/api/docs/swagger.json
@@ -1111,6 +1111,39 @@
                     }
                 }
             }
+        },
+        "/api/v1/version": {
+            "get": {
+                "description": "Returns the build version (commit hash) and release of the running Assertoor binary.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "Get build version information",
+                "operationId": "getVersion",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web_api.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/web_api.GetVersionResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1598,6 +1631,17 @@
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "web_api.GetVersionResponse": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/pkg/web/api/docs/swagger.yaml
+++ b/pkg/web/api/docs/swagger.yaml
@@ -323,6 +323,13 @@ definitions:
       source:
         type: string
     type: object
+  web_api.GetVersionResponse:
+    properties:
+      release:
+        type: string
+      version:
+        type: string
+    type: object
   web_api.LogEntry:
     properties:
       data:
@@ -1185,6 +1192,26 @@ paths:
       summary: Register new test via external test configuration
       tags:
       - Test
+  /api/v1/version:
+    get:
+      description: Returns the build version (commit hash) and release of the running
+        Assertoor binary.
+      operationId: getVersion
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            allOf:
+            - $ref: '#/definitions/web_api.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/web_api.GetVersionResponse'
+              type: object
+      summary: Get build version information
+      tags:
+      - Config
 swagger: "2.0"
 tags:
 - description: All endpoints related to test definitions

--- a/pkg/web/api/get_version_api.go
+++ b/pkg/web/api/get_version_api.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/ethpandaops/assertoor/pkg/buildinfo"
+)
+
+// GetVersionResponse contains build version information for the running Assertoor binary.
+type GetVersionResponse struct {
+	Version string `json:"version"`
+	Release string `json:"release"`
+}
+
+// GetVersion godoc
+// @Id getVersion
+// @Summary Get build version information
+// @Tags Config
+// @Description Returns the build version (commit hash) and release of the running Assertoor binary.
+// @Produce json
+// @Success 200 {object} Response{data=GetVersionResponse} "Success"
+// @Router /api/v1/version [get]
+func (ah *APIHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+
+	// ldflags inject values wrapped in literal quotes (see Makefile); strip them for a clean display.
+	ah.sendOKResponse(w, r.URL.String(), &GetVersionResponse{
+		Version: strings.Trim(buildinfo.BuildVersion, `"`),
+		Release: strings.Trim(buildinfo.BuildRelease, `"`),
+	})
+}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -103,6 +103,7 @@ func (ws *Server) ConfigureRoutes(frontendConfig *types.FrontendConfig, apiConfi
 		ws.router.HandleFunc("/api/v1/task_descriptor/{name}", apiHandler.GetTaskDescriptor).Methods("GET")
 		ws.router.HandleFunc("/api/v1/clients", apiHandler.GetClients).Methods("GET")
 		ws.router.HandleFunc("/api/v1/global_variables", apiHandler.GetGlobalVariables).Methods("GET")
+		ws.router.HandleFunc("/api/v1/version", apiHandler.GetVersion).Methods("GET")
 
 		// SSE event stream endpoints
 		if eventBus != nil {

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   ClientsPage,
   GlobalVariablesResponse,
   ScheduleTestRunRequest,
+  VersionResponse,
 } from '../types/api';
 import { authStore } from '../stores/authStore';
 
@@ -119,6 +120,11 @@ export async function getTaskDescriptor(name: string): Promise<TaskDescriptor> {
 // Global variable names (auth required)
 export async function getGlobalVariables(): Promise<GlobalVariablesResponse> {
   return fetchApiWithAuth<GlobalVariablesResponse>('/global_variables');
+}
+
+// Build version info
+export async function getVersion(): Promise<VersionResponse> {
+  return fetchApi<VersionResponse>('/version');
 }
 
 // Admin operations (require authentication)

--- a/web-ui/src/components/common/Layout.tsx
+++ b/web-ui/src/components/common/Layout.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
 import { Outlet, Link, useLocation, useMatch, matchPath } from 'react-router-dom';
 import { useTheme } from '../../hooks/useTheme';
 import { UserDisplay } from '../auth/UserDisplay';
+import { getVersion } from '../../api/client';
+import type { VersionResponse } from '../../types/api';
 
 const navItems = [
   { path: '/', label: 'Dashboard' },
@@ -15,6 +18,13 @@ function Layout() {
   const { theme, toggleTheme } = useTheme();
   const isTestRunPage = useMatch('/run/:runId');
   const isBuilderPage = matchPath('/builder', location.pathname);
+  const [version, setVersion] = useState<VersionResponse | null>(null);
+
+  useEffect(() => {
+    getVersion()
+      .then(setVersion)
+      .catch(() => setVersion(null));
+  }, []);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -83,6 +93,20 @@ function Layout() {
         <div className="max-w-screen-2xl mx-auto px-3 sm:px-4 lg:px-6">
           <p className="text-center text-sm text-[var(--color-text-tertiary)]">
             Assertoor - Ethereum Test Orchestration
+            {version?.version && (
+              <>
+                {' | '}
+                {version.release ? `${version.release} ` : ''}
+                <a
+                  href={`https://github.com/ethpandaops/assertoor/commit/${version.version}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono hover:underline"
+                >
+                  git-{version.version}
+                </a>
+              </>
+            )}
           </p>
         </div>
       </footer>

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -181,6 +181,12 @@ export interface GlobalVariablesResponse {
   names: string[];
 }
 
+// Build version info (from /api/v1/version)
+export interface VersionResponse {
+  version: string;
+  release: string;
+}
+
 // Client data
 export interface ClientData {
   index: number;


### PR DESCRIPTION
<img width="674" height="212" alt="Screenshot 2026-04-22 at 12 17 45" src="https://github.com/user-attachments/assets/2ce634d6-4833-4ed9-89e5-fd036d9fc4be" />


## Summary

- Adds a public `/api/v1/version` endpoint that returns the ldflags-injected `BuildVersion` / `BuildRelease`.
- Fetches it on layout mount and renders it in the footer (linked to the commit on GitHub) next to the existing "Assertoor - Ethereum Test Orchestration" tagline.
- Strips the literal quotes that `-X 'name="$(VERSION)"'` in the Makefile bakes into the string so the footer shows `git-<sha>` cleanly.
- Regenerated Swagger docs for the new endpoint.

Mirrors the approach used in `ethpandaops/dora` where the footer shows the built commit, so operators can tell at a glance which build is running.

## Test plan
- [x] `go build ./...`
- [x] `npx tsc --noEmit` in `web-ui`
- [x] `make docs` regenerates Swagger without errors
- [ ] Manually verify the footer displays `git-<sha>` when a built binary is served (not validated — no local devnet run in this change)