### PR TITLE
ci: drop macos/amd64 release builds

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -191,48 +191,6 @@ jobs:
         path: ./bin/*
         name: assertoor_windows_amd64
 
-  build_darwin_amd64_binary:
-    name: Build macos/amd64 binary
-    needs: [build_frontend]
-    runs-on: macos-15-intel
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-
-    # setup global dependencies
-    - name: Set up go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.25.x
-
-    # download frontend artifacts
-    - name: Download frontend artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: frontend
-        path: ./pkg/web/static
-
-    # setup project dependencies
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
-    # build binaries
-    - name: Build macos amd64 binary
-      run: |
-        make docs
-        make build
-      env:
-        RELEASE: ${{ inputs.release }}
-
-    # upload artifacts
-    - name: "Upload artifact: assertoor_darwin_amd64"
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        path: ./bin/*
-        name: assertoor_darwin_amd64
-
   build_darwin_arm64_binary:
     name: Build macos/arm64 binary
     needs: [build_frontend]

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -105,10 +105,6 @@ jobs:
       run: |
         cd assertoor_linux_arm64
         tar -czf ../assertoor_snapshot_linux_arm64.tar.gz .
-    - name: "Generate release package: assertoor_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd assertoor_darwin_amd64
-        tar -czf ../assertoor_snapshot_darwin_amd64.tar.gz .
     - name: "Generate release package: assertoor_snapshot_darwin_arm64.tar.gz"
       run: |
         cd assertoor_darwin_arm64
@@ -133,11 +129,9 @@ jobs:
           | [assertoor_snapshot_windows_amd64.zip](https://github.com/ethpandaops/assertoor/releases/download/snapshot/assertoor_snapshot_windows_amd64.zip) | assertoor executables for windows/amd64 |
           | [assertoor_snapshot_linux_amd64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/snapshot/assertoor_snapshot_linux_amd64.tar.gz) | assertoor executables for linux/amd64 |
           | [assertoor_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/snapshot/assertoor_snapshot_linux_arm64.tar.gz) | assertoor executables for linux/arm64 |
-          | [assertoor_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/snapshot/assertoor_snapshot_darwin_amd64.tar.gz) | assertoor executable for macos/amd64 |
           | [assertoor_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/snapshot/assertoor_snapshot_darwin_arm64.tar.gz) | assertoor executable for macos/arm64 |
         files: |
           assertoor_snapshot_windows_amd64.zip
           assertoor_snapshot_linux_amd64.tar.gz
           assertoor_snapshot_linux_arm64.tar.gz
-          assertoor_snapshot_darwin_amd64.tar.gz
           assertoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,10 +67,6 @@ jobs:
       run: |
         cd assertoor_linux_arm64
         tar -czf ../assertoor_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Generate release package: assertoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd assertoor_darwin_amd64
-        tar -czf ../assertoor_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Generate release package: assertoor_${{ inputs.version }}_darwin_arm64.tar.gz"
       run: |
         cd assertoor_darwin_arm64
@@ -95,11 +91,9 @@ jobs:
           | [assertoor_${{ inputs.version }}_windows_amd64.zip](https://github.com/ethpandaops/assertoor/releases/download/v${{ inputs.version }}/assertoor_${{ inputs.version }}_windows_amd64.zip) | assertoor executables for windows/amd64 |
           | [assertoor_${{ inputs.version }}_linux_amd64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/v${{ inputs.version }}/assertoor_${{ inputs.version }}_linux_amd64.tar.gz) | assertoor executables for linux/amd64 |
           | [assertoor_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/v${{ inputs.version }}/assertoor_${{ inputs.version }}_linux_arm64.tar.gz) | assertoor executables for linux/arm64 |
-          | [assertoor_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/v${{ inputs.version }}/assertoor_${{ inputs.version }}_darwin_amd64.tar.gz) | assertoor executable for macos/amd64 |
           | [assertoor_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/assertoor/releases/download/v${{ inputs.version }}/assertoor_${{ inputs.version }}_darwin_arm64.tar.gz) | assertoor executable for macos/arm64 |
         files: |
           assertoor_${{ inputs.version }}_windows_amd64.zip
           assertoor_${{ inputs.version }}_linux_amd64.tar.gz
           assertoor_${{ inputs.version }}_linux_arm64.tar.gz
-          assertoor_${{ inputs.version }}_darwin_amd64.tar.gz
           assertoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Remove the `build_darwin_amd64_binary` job from the shared build workflow
- Drop the darwin_amd64 tarball steps, release-notes table row, and files entry from snapshot/release workflows
- Mac builds are now arm64-only

## Test plan
- [ ] Trigger snapshot build and confirm artifacts contain only windows_amd64, linux_amd64, linux_arm64, darwin_arm64
- [ ] On the next tagged release, confirm artifacts and release-notes table match