### PR TITLE
fix: prevent eoa/blob tx generator from stalling on pre-submission errors

### DIFF
--- a/pkg/tasks/generate_blob_transactions/task.go
+++ b/pkg/tasks/generate_blob_transactions/task.go
@@ -165,7 +165,7 @@ func (t *Task) Execute(ctx context.Context) error {
 			}
 		}
 
-		err := t.generateTransaction(ctx, txIndex, func(tx *ethtypes.Transaction, receipt *ethtypes.Receipt, err error) {
+		handedOff, err := t.generateTransaction(ctx, txIndex, func(tx *ethtypes.Transaction, receipt *ethtypes.Receipt, err error) {
 			if pendingChan != nil {
 				<-pendingChan
 			}
@@ -182,8 +182,13 @@ func (t *Task) Execute(ctx context.Context) error {
 		if err != nil {
 			t.logger.Errorf("error generating transaction: %v", err.Error())
 
-			// Note: onComplete callback is still called by spamoor even on error,
-			// so we don't drain pendingChan here
+			if !handedOff {
+				// The tx was never handed to spamoor, so its OnComplete callback
+				// will never fire; release the pending slot here.
+				if pendingChan != nil {
+					<-pendingChan
+				}
+			}
 		} else {
 			perBlockCount++
 			totalCount++
@@ -261,7 +266,11 @@ func (t *Task) isFuluActive() bool {
 	return currentEpoch.Number() >= fuluEpoch
 }
 
-func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, completeFn spamoor.TxCompleteFn) error {
+// generateTransaction builds and submits a single blob transaction.
+// The returned bool reports whether the tx was handed off to spamoor: when true,
+// spamoor owns the OnComplete callback (even if an error is also returned); when
+// false, the tx never reached submission and the caller must release its pending slot.
+func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, completeFn spamoor.TxCompleteFn) (bool, error) {
 	txWallet := t.wallet
 	if t.wallet == nil {
 		txWallet = t.walletPool.GetWallet(spamoor.SelectWalletRoundRobin, 0)
@@ -337,12 +346,16 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 	if t.config.ClientPattern == "" && t.config.ExcludeClientPattern == "" {
 		clients = clientPool.GetExecutionPool().AwaitReadyEndpoints(ctx, true)
 		if len(clients) == 0 {
-			return ctx.Err()
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+
+			return false, fmt.Errorf("no ready execution clients available")
 		}
 	} else {
 		poolClients := clientPool.GetClientsByNamePatterns(t.config.ClientPattern, t.config.ExcludeClientPattern)
 		if len(poolClients) == 0 {
-			return fmt.Errorf("no client found with pattern %v", t.config.ClientPattern)
+			return false, fmt.Errorf("no client found with pattern %v", t.config.ClientPattern)
 		}
 
 		clients = make([]*execution.Client, len(poolClients))
@@ -368,12 +381,12 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 		Data:       txData,
 	}, blobRefs)
 	if err != nil {
-		return fmt.Errorf("cannot build blob tx data: %w", err)
+		return false, fmt.Errorf("cannot build blob tx data: %w", err)
 	}
 
 	tx, err := txWallet.BuildBlobTx(blobTx)
 	if err != nil {
-		return fmt.Errorf("cannot build blob transaction: %w", err)
+		return false, fmt.Errorf("cannot build blob transaction: %w", err)
 	}
 
 	// Check if Fulu is active to determine blob sidecar version.
@@ -425,8 +438,8 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 	err = walletMgr.GetTxPool().SendTransaction(ctx, txWallet, tx, sendOpts)
 	if err != nil {
 		txWallet.MarkSkippedNonce(tx.Nonce())
-		return err
+		return true, err
 	}
 
-	return nil
+	return true, nil
 }

--- a/pkg/tasks/generate_eoa_transactions/task.go
+++ b/pkg/tasks/generate_eoa_transactions/task.go
@@ -173,7 +173,7 @@ func (t *Task) Execute(ctx context.Context) error {
 
 		pendingWaitGroup.Add(1)
 
-		err := t.generateTransaction(ctx, txIndex, func(tx *ethtypes.Transaction, receipt *ethtypes.Receipt, err error) {
+		handedOff, err := t.generateTransaction(ctx, txIndex, func(tx *ethtypes.Transaction, receipt *ethtypes.Receipt, err error) {
 			if pendingChan != nil {
 				<-pendingChan
 			}
@@ -202,8 +202,15 @@ func (t *Task) Execute(ctx context.Context) error {
 		if err != nil {
 			t.logger.Errorf("error generating transaction: %v", err.Error())
 
-			// Note: onComplete callback is still called by spamoor even on error,
-			// so we don't drain pendingChan or call pendingWaitGroup.Done() here
+			if !handedOff {
+				// The tx was never handed to spamoor, so its OnComplete callback
+				// will never fire; release the pending slot and waitgroup entry here.
+				if pendingChan != nil {
+					<-pendingChan
+				}
+
+				pendingWaitGroup.Done()
+			}
 		} else {
 			perBlockCount++
 			totalCount++
@@ -257,7 +264,11 @@ func (t *Task) Execute(ctx context.Context) error {
 	return nil
 }
 
-func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, completeFn spamoor.TxCompleteFn) error {
+// generateTransaction builds and submits a single transaction.
+// The returned bool reports whether the tx was handed off to spamoor: when true,
+// spamoor owns the OnComplete callback (even if an error is also returned); when
+// false, the tx never reached submission and the caller must release its pending slot.
+func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, completeFn spamoor.TxCompleteFn) (bool, error) {
 	txWallet := t.wallet
 	if t.wallet == nil {
 		txWallet = t.walletPool.GetWallet(spamoor.SelectWalletRoundRobin, 0)
@@ -301,12 +312,16 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 	if t.config.ClientPattern == "" && t.config.ExcludeClientPattern == "" {
 		clients = clientPool.GetExecutionPool().AwaitReadyEndpoints(ctx, true)
 		if len(clients) == 0 {
-			return ctx.Err()
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+
+			return false, fmt.Errorf("no ready execution clients available")
 		}
 	} else {
 		poolClients := clientPool.GetClientsByNamePatterns(t.config.ClientPattern, t.config.ExcludeClientPattern)
 		if len(poolClients) == 0 {
-			return fmt.Errorf("no client found with pattern %v", t.config.ClientPattern)
+			return false, fmt.Errorf("no client found with pattern %v", t.config.ClientPattern)
 		}
 
 		clients = make([]*execution.Client, len(poolClients))
@@ -328,7 +343,7 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 			Data:      txData,
 		})
 		if buildErr != nil {
-			return fmt.Errorf("cannot build legacy tx data: %w", buildErr)
+			return false, fmt.Errorf("cannot build legacy tx data: %w", buildErr)
 		}
 
 		tx, err = txWallet.BuildLegacyTx(legacyTx)
@@ -342,14 +357,14 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 			Data:      txData,
 		})
 		if buildErr != nil {
-			return fmt.Errorf("cannot build dynamic fee tx data: %w", buildErr)
+			return false, fmt.Errorf("cannot build dynamic fee tx data: %w", buildErr)
 		}
 
 		tx, err = txWallet.BuildDynamicFeeTx(dynFeeTx)
 	}
 
 	if err != nil {
-		return fmt.Errorf("cannot build transaction: %w", err)
+		return false, fmt.Errorf("cannot build transaction: %w", err)
 	}
 
 	walletMgr := t.ctx.Scheduler.GetServices().WalletManager()
@@ -390,8 +405,8 @@ func (t *Task) generateTransaction(ctx context.Context, transactionIdx uint64, c
 	})
 	if err != nil {
 		txWallet.MarkSkippedNonce(tx.Nonce())
-		return err
+		return true, err
 	}
 
-	return nil
+	return true, nil
 }


### PR DESCRIPTION
## Problem

The producer loop in `generate_eoa_transactions` (and the identical `generate_blob_transactions`) acquires a slot in the `pendingChan` semaphore — and, for the EOA task, an entry in `pendingWaitGroup` — on every iteration, and relies on spamoor's `OnComplete` callback to release it. The error branch even documents this:

```go
// Note: onComplete callback is still called by spamoor even on error,
// so we don't drain pendingChan or call pendingWaitGroup.Done() here
```

That assumption only holds once the tx has been handed to `SendTransaction`. `generateTransaction` has several error paths that return **before** the hand-off:

- no ready execution clients (`AwaitReadyEndpoints` returns empty),
- no client matches the configured `clientPattern`,
- tx-build failure (`txbuilder.LegacyTx` / `DynFeeTx` / `Build*Tx`).

On those paths `OnComplete` never fires, so each error **leaks a pending slot** (and a waitgroup entry). After `LimitPending` such errors the loop blocks forever on `pendingChan <- true` and the generator silently stops producing transactions for the rest of the run — the background task never completes and any foreground `check_consensus_block_proposals` waiting on it times out.

Separately, the no-ready-clients path returned `ctx.Err()`, which is `nil` when the context is still live — so a transient "no clients" condition was counted as a *successful* send rather than an error.

## Fix

`generateTransaction` now returns whether the tx was handed off to spamoor:

- **handed off** (including when `SendTransaction` itself returns an error, since spamoor still invokes `OnComplete` in that case) → the callback owns the slot release, exactly as before.
- **not handed off** → the caller releases the pending slot (and waitgroup entry) synchronously.

The no-clients path now returns an explicit error instead of a nil `ctx.Err()`.

This is a latent same-class bug as one that surfaced while investigating an erigon kurtosis/assertoor CI stall: a transient, recoverable submission hiccup should not permanently wedge the generator.

## Notes

- `go build ./...`, `go vet`, and `golangci-lint run` (v2.11.3) are clean.
- No unit test is included: the repo currently has no task-level test scaffolding/mocks for the `TaskContext`/`Scheduler`/spamoor `TxPool` dependencies, and the fix is localized and verified by build/lint + reasoning. Happy to add a harness-based test if you'd prefer.
- The same `pendingChan`/`OnComplete` pattern exists in `generate_consolidations`, `generate_deposits`, and `generate_withdrawal_requests`; those have larger, more varied bodies, so I kept this PR focused on the two transaction-spamming generators. Happy to follow up on the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)