### PR TITLE
fix(run_shell): inherit parent environment in spawned shell

### DIFF
--- a/pkg/tasks/run_shell/task.go
+++ b/pkg/tasks/run_shell/task.go
@@ -101,6 +101,11 @@ func (t *Task) Execute(ctx context.Context) error {
 	//nolint:gosec // ignore
 	command := exec.CommandContext(ctx, t.config.Shell, t.config.ShellArgs...)
 
+	// Inherit parent environment so spawned shells have HOME/PATH/USER.
+	// Without this, exec.Cmd.Env is nil and the child inherits nothing;
+	// user-supplied envVars below still take precedence via append order.
+	command.Env = append(command.Env, os.Environ()...)
+
 	stdin, err := command.StdinPipe()
 	if err != nil {
 		cmdLogger.Errorf("failed getting stdin pipe")


### PR DESCRIPTION
## Summary

- Adds `command.Env = append(command.Env, os.Environ()...)` before the user-supplied `envVars` in `pkg/tasks/run_shell/task.go`
- When `exec.Cmd.Env` is set to a non-nil slice, Go does **not** inherit the parent environment — `HOME`, `PATH`, `USER`, `SHELL` are all unset in the child process
- User-supplied `envVars` from the task config are still appended after, so they continue to override inherited values

## Why this matters

Without this fix, two common patterns silently break:
1. **`pip install --user` tools** (e.g. `uv`) install to `$HOME/.local/bin`. With `$HOME` unset, `~/.profile` never adds that directory to `PATH`, so the binary is not found (exit 127)
2. **`foundryup`** reads `$SHELL` to decide which profile to update. With `$SHELL` unset it exits 1

Both were worked around in playbooks with `sudo pip install` and `export SHELL=/bin/bash`, but fixing it at the task level is cleaner.

## Test plan

- [ ] `run_shell` task with `pip install --user somepackage && somepackage --version` succeeds without `export PATH` workaround
- [ ] `run_shell` task running `foundryup` succeeds without `export SHELL=/bin/bash` prefix