### PR TITLE
Fix `check_consensus_attestation_stats`: post-Electra & support for minimal network

### DIFF
--- a/pkg/tasks/check_consensus_attestation_stats/task.go
+++ b/pkg/tasks/check_consensus_attestation_stats/task.go
@@ -499,10 +499,15 @@ func (t *Task) aggregateEpochVotes(ctx context.Context, epoch uint64) []*epochVo
 						continue
 					}
 
+					// committeeBits is a bitfield.Bitvector64, whose BitAt only works at
+					// the mainnet 8-byte size; under smaller presets it is shorter, so we
+					// test the bits length-agnostically (see committeeBitSet).
+					committeeBitsBytes := []byte(committeeBits)
+
 					aggregationBitsOffset := uint64(0)
 
 					for committee := uint64(0); committee < specs.MaxCommitteesPerSlot; committee++ {
-						if !committeeBits.BitAt(committee) {
+						if !committeeBitSet(committeeBitsBytes, committee) {
 							continue
 						}
 
@@ -557,6 +562,12 @@ func (t *Task) aggregateEpochVotes(ctx context.Context, epoch uint64) []*epochVo
 	t.logger.Debugf("aggregated epoch %v votes in %v", epoch, time.Since(t1))
 
 	return votes
+}
+
+// committeeBitSet reports whether the committee-th bit is set in b.
+func committeeBitSet(b []byte, committee uint64) bool {
+	byteIdx := committee / 8
+	return byteIdx < uint64(len(b)) && b[byteIdx]&(1<<(committee%8)) != 0
 }
 
 func (t *Task) aggregateAttestationVotes(votes *epochVotes, slot, committee uint64, aggregationBits bitfield.Bitfield, aggregationBitsOffset uint64) (voteAmount, voteCount, validatorCount uint64) {

--- a/pkg/tasks/check_consensus_attestation_stats/task.go
+++ b/pkg/tasks/check_consensus_attestation_stats/task.go
@@ -506,7 +506,7 @@ func (t *Task) aggregateEpochVotes(ctx context.Context, epoch uint64) []*epochVo
 							continue
 						}
 
-						voteAmt, voteCnt, committeeSize := t.aggregateAttestationVotes(votes, uint64(attData.Slot), committee, attAggregationBits, 0)
+						voteAmt, voteCnt, committeeSize := t.aggregateAttestationVotes(votes, uint64(attData.Slot), committee, attAggregationBits, aggregationBitsOffset)
 						voteAmount += voteAmt
 						voteCount += voteCnt
 						aggregationBitsOffset += committeeSize


### PR DESCRIPTION
06b7f967e28a5d4715d6254aff1181969dac01d5: `aggregationBitsOffset` is accumulated in every loop body, but never used in calculation. Fixing this for post-Electra.
715a92e30333afb7f3f6b73f109c5a8f367c3cca: If `MAX_COMMITTEES_PER_SLOT` is 4, `len(committeeBits)` is just 1, so `BitAt` for `Bitvector64` will always fail because of the gate: `len(b) != bitvector64ByteSize`. This was critical for my local setup as I'm using assertoor for minimal network.