### PR TITLE
change builder withdrawal prefix from 0x03 to 0xB0

### DIFF
--- a/pkg/tasks/check_consensus_block_proposals/config.go
+++ b/pkg/tasks/check_consensus_block_proposals/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	} `yaml:"expectConsolidationRequests" json:"expectConsolidationRequests" desc:"List of expected consolidation requests in the block."`
 	ExpectBuilderDepositRequests []struct {
 		PublicKey             string   `yaml:"publicKey" json:"publicKey" desc:"Public key of the builder."`
-		WithdrawalCredentials string   `yaml:"withdrawalCredentials" json:"withdrawalCredentials" desc:"Withdrawal credentials (0x03-prefixed)."`
+		WithdrawalCredentials string   `yaml:"withdrawalCredentials" json:"withdrawalCredentials" desc:"Withdrawal credentials (0xB0-prefixed)."`
 		Amount                *big.Int `yaml:"amount" json:"amount" desc:"Builder deposit amount in gwei."`
 	} `yaml:"expectBuilderDepositRequests" json:"expectBuilderDepositRequests" desc:"List of expected builder deposit requests (EIP-8282) in the block."`
 	ExpectBuilderExitRequests []struct {

--- a/pkg/tasks/generate_batch_deposits/README.md
+++ b/pkg/tasks/generate_batch_deposits/README.md
@@ -26,7 +26,7 @@ If `batchContract` is empty the task deploys a fresh forwarder bound to the conf
 - **`batchTxGasLimit`**: Gas limit per batched transaction. Default `12_000_000`.
 - **`depositAmount`**: ETH amount per deposit. Default `32` ETH.
 - **`depositTxFeeCap`** / **`depositTxTipCap`**: Fee/tip caps (wei) for batch transactions.
-- **`withdrawalCredentials`**: Required 32-byte withdrawal credentials shared by every deposit in every batch (e.g. `0x03 + 11 zero bytes + 20-byte address` for builder credentials).
+- **`withdrawalCredentials`**: Required 32-byte withdrawal credentials shared by every deposit in every batch (e.g. `0xB0 + 11 zero bytes + 20-byte address` for builder credentials).
 - **`clientPattern`** / **`excludeClientPattern`**: Client selection regexes.
 - **`awaitReceipt`**: Wait for every batch transaction receipt before completing.
 - **`failOnReject`**: Fail the task if any batch transaction is rejected or reverted.

--- a/pkg/tasks/generate_batch_deposits/config.go
+++ b/pkg/tasks/generate_batch_deposits/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	DepositAmount         uint64 `yaml:"depositAmount" json:"depositAmount" desc:"Amount of ETH to deposit per validator. Default 32 ETH."`
 	DepositTxFeeCap       int64  `yaml:"depositTxFeeCap" json:"depositTxFeeCap" desc:"Maximum fee cap (in wei) for batch transactions."`
 	DepositTxTipCap       int64  `yaml:"depositTxTipCap" json:"depositTxTipCap" desc:"Maximum priority tip (in wei) for batch transactions."`
-	WithdrawalCredentials string `yaml:"withdrawalCredentials" json:"withdrawalCredentials" require:"E" desc:"32-byte withdrawal credentials shared by all deposits in every batch. For 0x03 builder credentials use '0x03' + 11 zero bytes + 20-byte address."`
+	WithdrawalCredentials string `yaml:"withdrawalCredentials" json:"withdrawalCredentials" require:"E" desc:"32-byte withdrawal credentials shared by all deposits in every batch. For 0xB0 builder credentials use '0xB0' + 11 zero bytes + 20-byte address."`
 	ClientPattern         string `yaml:"clientPattern" json:"clientPattern" desc:"Regex pattern to select specific client endpoints for submitting transactions."`
 	ExcludeClientPattern  string `yaml:"excludeClientPattern" json:"excludeClientPattern" desc:"Regex pattern to exclude certain client endpoints."`
 	AwaitReceipt          bool   `yaml:"awaitReceipt" json:"awaitReceipt" desc:"Wait for batch transaction receipts on the execution layer before completing."`

--- a/pkg/tasks/generate_builder_deposits/README.md
+++ b/pkg/tasks/generate_builder_deposits/README.md
@@ -7,7 +7,7 @@ The raw 184-byte calldata layout is:
 
 ```
 0-48:    pubkey (48 bytes)
-48-80:   withdrawal credentials (32 bytes, 0x03-prefixed)
+48-80:   withdrawal credentials (32 bytes, 0xB0-prefixed)
 80-88:   amount (8 bytes, big-endian gwei)
 88-184:  signature (96 bytes, BLS proof-of-possession)
 ```
@@ -49,10 +49,10 @@ Builders are identified either by deriving keys from a `mnemonic` & key range, o
   Amount of ETH to deposit per builder. Must be at least `1` ETH (`BUILDER_MIN_DEPOSIT`).
 
 - **`withdrawalCredentials`**:
-  Custom withdrawal credentials (must be 0x03-prefixed, 32 bytes). If empty, credentials are derived from `builderAddress`, or from the funding wallet address.
+  Custom withdrawal credentials (must be 0xB0-prefixed, 32 bytes). If empty, credentials are derived from `builderAddress`, or from the funding wallet address.
 
 - **`builderAddress`**:
-  Execution address used to build the 0x03 withdrawal credentials when `withdrawalCredentials` is not set. This address is the only one allowed to exit the builder later.
+  Execution address used to build the 0xB0 withdrawal credentials when `withdrawalCredentials` is not set. This address is the only one allowed to exit the builder later.
 
 - **`topUpDeposit`**:
   If true, adds to an existing builder balance instead of registering a new builder.

--- a/pkg/tasks/generate_builder_deposits/config.go
+++ b/pkg/tasks/generate_builder_deposits/config.go
@@ -16,8 +16,8 @@ type Config struct {
 	WalletPrivkey          string   `yaml:"walletPrivkey" json:"walletPrivkey" require:"C" desc:"Private key of the wallet used to fund builder deposit transactions."`
 	BuilderDepositContract string   `yaml:"builderDepositContract" json:"builderDepositContract" desc:"Address of the builder deposit system contract (EIP-8282)."`
 	DepositAmount          uint64   `yaml:"depositAmount" json:"depositAmount" desc:"Amount of ETH to deposit per builder (must be >= 1 ETH)."`
-	WithdrawalCredentials  string   `yaml:"withdrawalCredentials" json:"withdrawalCredentials" desc:"Custom withdrawal credentials to use (must be 0x03-prefixed). If empty, derived from builderAddress or the funding wallet address."`
-	BuilderAddress         string   `yaml:"builderAddress" json:"builderAddress" desc:"Execution address used to build 0x03 withdrawal credentials when withdrawalCredentials is not set. This address is the only one allowed to exit the builder."`
+	WithdrawalCredentials  string   `yaml:"withdrawalCredentials" json:"withdrawalCredentials" desc:"Custom withdrawal credentials to use (must be 0xB0-prefixed). If empty, derived from builderAddress or the funding wallet address."`
+	BuilderAddress         string   `yaml:"builderAddress" json:"builderAddress" desc:"Execution address used to build 0xB0 withdrawal credentials when withdrawalCredentials is not set. This address is the only one allowed to exit the builder."`
 	TopUpDeposit           bool     `yaml:"topUpDeposit" json:"topUpDeposit" desc:"If true, add to an existing builder balance instead of registering a new builder. Withdrawal credentials and signature are ignored by the consensus layer for top-ups."`
 	TxFeeCap               *big.Int `yaml:"txFeeCap" json:"txFeeCap" desc:"Maximum fee cap (in wei) for builder deposit transactions."`
 	TxTipCap               *big.Int `yaml:"txTipCap" json:"txTipCap" desc:"Maximum priority tip (in wei) for builder deposit transactions."`

--- a/pkg/tasks/generate_builder_deposits/task.go
+++ b/pkg/tasks/generate_builder_deposits/task.go
@@ -556,7 +556,7 @@ func (t *Task) generateBuilderDeposit(ctx context.Context, accountIdx uint64, on
 }
 
 // builderWithdrawalCredentials returns the 32-byte withdrawal credentials for the
-// builder deposit. Builder deposits require 0x03-prefixed credentials.
+// builder deposit. Builder deposits require 0xB0-prefixed credentials.
 func (t *Task) builderWithdrawalCredentials() ([]byte, error) {
 	if t.config.TopUpDeposit {
 		// Credentials are ignored by the consensus layer for top-ups.
@@ -572,7 +572,7 @@ func (t *Task) builderWithdrawalCredentials() ([]byte, error) {
 		return creds, nil
 	}
 
-	// Derive 0x03 credentials from the builder address, or the funding wallet address.
+	// Derive 0xB0 credentials from the builder address, or the funding wallet address.
 	var addr ethcommon.Address
 	if t.config.BuilderAddress != "" {
 		addr = ethcommon.HexToAddress(t.config.BuilderAddress)
@@ -581,7 +581,7 @@ func (t *Task) builderWithdrawalCredentials() ([]byte, error) {
 	}
 
 	creds := make([]byte, 32)
-	creds[0] = 0x03
+	creds[0] = 0xB0
 	copy(creds[12:], addr[:])
 
 	return creds, nil

--- a/pkg/tasks/generate_builder_exits/README.md
+++ b/pkg/tasks/generate_builder_exits/README.md
@@ -3,7 +3,7 @@
 ### Description
 The `generate_builder_exits` task generates and submits builder exit requests to the Ethereum network as defined by EIP-8282 (Gloas). As of Gloas, builder exits are **no longer voluntary (consensus-layer) exits** — they are submitted as execution-layer requests to the builder exit system contract.
 
-The request is submitted as **raw calldata** (no function selector): the 48-byte builder public key. The contract prepends `msg.sender` as the source address when emitting the request, so the transaction **must be sent from the builder's execution address** (the address embedded in its 0x03 withdrawal credentials). Only that address is authorized to exit the builder.
+The request is submitted as **raw calldata** (no function selector): the 48-byte builder public key. The contract prepends `msg.sender` as the source address when emitting the request, so the transaction **must be sent from the builder's execution address** (the address embedded in its 0xB0 withdrawal credentials). Only that address is authorized to exit the builder.
 
 The builders to exit can be specified either by an explicit `sourcePubkey`, or by deriving keys from a `sourceMnemonic` & key range.
 
@@ -31,7 +31,7 @@ The builders to exit can be specified either by an explicit `sourcePubkey`, or b
   Number of builders to generate exit requests for.
 
 - **`walletPrivkey`**:
-  Private key of the wallet used to send builder exit transactions. Must match the builder's execution address (its 0x03 withdrawal credentials).
+  Private key of the wallet used to send builder exit transactions. Must match the builder's execution address (its 0xB0 withdrawal credentials).
 
 - **`builderExitContract`**:
   Address of the builder exit system contract (EIP-8282).

--- a/pkg/tasks/generate_builder_exits/config.go
+++ b/pkg/tasks/generate_builder_exits/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	SourceMnemonic       string   `yaml:"sourceMnemonic" json:"sourceMnemonic" require:"B.2" desc:"Mnemonic phrase to derive builder keys for exits."`
 	SourceStartIndex     int      `yaml:"sourceStartIndex" json:"sourceStartIndex" require:"B.2" desc:"Index within the mnemonic from which to start deriving builder keys."`
 	SourceIndexCount     int      `yaml:"sourceIndexCount" json:"sourceIndexCount" desc:"Number of builders to generate exit requests for."`
-	WalletPrivkey        string   `yaml:"walletPrivkey" json:"walletPrivkey" require:"C" desc:"Private key of the wallet used to send builder exit transactions. Must match the builder's execution address (its 0x03 withdrawal credentials)."`
+	WalletPrivkey        string   `yaml:"walletPrivkey" json:"walletPrivkey" require:"C" desc:"Private key of the wallet used to send builder exit transactions. Must match the builder's execution address (its 0xB0 withdrawal credentials)."`
 	BuilderExitContract  string   `yaml:"builderExitContract" json:"builderExitContract" desc:"Address of the builder exit system contract (EIP-8282)."`
 	TxAmount             *big.Int `yaml:"txAmount" json:"txAmount" desc:"Amount of ETH (in wei) to send with the builder exit transaction to cover the request fee."`
 	TxFeeCap             *big.Int `yaml:"txFeeCap" json:"txFeeCap" desc:"Maximum fee cap (in wei) for builder exit transactions."`

--- a/playbooks/_index.yaml
+++ b/playbooks/_index.yaml
@@ -45,7 +45,7 @@ folders:
     name: GLOAS (ePBS)
     description: |-
       GLOAS-fork tests focused on the ePBS payload-publishing model and the
-      new builder role (validators with 0x03 withdrawal credentials).
+      new builder role (validators with 0xB0 withdrawal credentials).
 
       Includes builder lifecycle, builder deposit spam, and regression tests
       for the `process_previous_payload` ordering rule that affects how
@@ -472,11 +472,11 @@ playbooks:
     timeout: 4h
   - file: gloas-dev/builder-deposit-spam.yaml
     id: builder-deposit-spam
-    name: 'GLOAS: Spam batched 0x03 builder deposits'
+    name: 'GLOAS: Spam batched 0xB0 builder deposits'
     description: |-
       Stress test for the GLOAS builder deposit path. Deploys a tiny batch
       contract and uses it to register `totalDeposits` (default 1000)
-      builders with 0x03 credentials at `batchSize` (default 100) deposits
+      builders with 0xB0 credentials at `batchSize` (default 100) deposits
       per tx, capped at `pendingBatches` in-flight.
 
       After spamming, asserts the chain still finalizes (1 finalized epoch,
@@ -496,11 +496,11 @@ playbooks:
     timeout: 1h
   - file: gloas-dev/builder-deposit.yaml
     id: builder-deposit
-    name: 'GLOAS: Builder Deposit (0x03 credentials)'
+    name: 'GLOAS: Builder Deposit (0xB0 credentials)'
     description: |-
       Minimal deposit test for the GLOAS builder role. Generates a fresh
-      wallet + mnemonic and submits a single 5-ETH deposit with 0x03
-      withdrawal credentials (i.e. `0x03 || 11×0x00 || 20-byte address`).
+      wallet + mnemonic and submits a single 5-ETH deposit with 0xB0
+      withdrawal credentials (i.e. `0xB0 || 11×0x00 || 20-byte address`).
 
       Verifies the deposit pipeline accepts builder-tagged credentials
       on a GLOAS devnet. Awaits both EL receipt and CL inclusion.
@@ -515,7 +515,7 @@ playbooks:
     id: builder-lifecycle
     name: 'GLOAS: Builder Lifecycle Test'
     description: |-
-      End-to-end lifecycle for GLOAS builders (validators with 0x03
+      End-to-end lifecycle for GLOAS builders (validators with 0xB0
       withdrawal credentials). Walks 10 builder keys through:
 
       1. Deposit 6 builders across the GLOAS activation boundary (3 before,

--- a/playbooks/gloas-dev/_header.yaml
+++ b/playbooks/gloas-dev/_header.yaml
@@ -1,7 +1,7 @@
 name: GLOAS (ePBS)
 description: |
   GLOAS-fork tests focused on the ePBS payload-publishing model and the
-  new builder role (validators with 0x03 withdrawal credentials).
+  new builder role (validators with 0xB0 withdrawal credentials).
 
   Includes builder lifecycle, builder deposit spam, and regression tests
   for the `process_previous_payload` ordering rule that affects how

--- a/playbooks/gloas-dev/builder-deposit.yaml
+++ b/playbooks/gloas-dev/builder-deposit.yaml
@@ -7,7 +7,7 @@ description: |
 
   Builder deposits are submitted as raw calldata (no deposit() selector):
   `pubkey || withdrawal_credentials || amount || signature`, signed under
-  DOMAIN_BUILDER_DEPOSIT. The withdrawal credentials default to 0x03 +
+  DOMAIN_BUILDER_DEPOSIT. The withdrawal credentials default to 0xB0 +
   the funding wallet address, so the same wallet can later exit the
   builder. Awaits both EL receipt and CL inclusion as a builder deposit
   request.

--- a/playbooks/gloas-dev/builder-lifecycle.yaml
+++ b/playbooks/gloas-dev/builder-lifecycle.yaml
@@ -6,7 +6,7 @@ description: |
 
   When the test is started BEFORE GLOAS activation:
   1. PRE-FORK onboarding: deposit builderCount builders a few slots BEFORE GLOAS
-     activates, using the regular validator deposit contract with 0x03 (builder)
+     activates, using the regular validator deposit contract with 0xB0 (builder)
      withdrawal credentials. These deposits sit in the pending-deposit queue and,
      because they reach the fork unprocessed, are converted to builders at the
      fork by `onboard_builders_from_pending_deposits`. Their signatures are
@@ -35,7 +35,7 @@ tags: [gloas, builder, lifecycle, deposit, exit, eip-8282]
 timeout: 2h
 config:
   walletPrivkey: ''
-  # Regular validator deposit contract (pre-fork builder onboarding via 0x03 creds).
+  # Regular validator deposit contract (pre-fork builder onboarding via 0xB0 creds).
   depositContract: '0x00000000219ab540356cBB839Cbe05303d7705Fa'
   # EIP-8282 builder system contracts (post-fork deposits / exits).
   builderDepositContract: '0x0000884d2AA32eAa155F59A2f24eFa73D9008282'
@@ -137,7 +137,7 @@ tasks:
 ##
 ## PHASE 1a: PRE-FORK onboarding (only when started before the fork)
 ##  Deposit builderCount builders (keys 0..builderCount-1) via the regular deposit
-##  contract with 0x03 credentials, before GLOAS activates. They are onboarded as
+##  contract with 0xB0 credentials, before GLOAS activates. They are onboarded as
 ##  builders at the fork (onboard_builders_from_pending_deposits), which verifies
 ##  the signature under the regular DOMAIN_DEPOSIT.
 ##
@@ -151,7 +151,7 @@ tasks:
 
 - name: generate_deposits
   id: prefork_deposits
-  title: "Pre-fork: deposit ${builderCount} builders (regular contract, 0x03 creds)"
+  title: "Pre-fork: deposit ${builderCount} builders (regular contract, 0xB0 creds)"
   if: "| .tasks.calc_slots.outputs.isPreFork"
   config:
     awaitReceipt: true
@@ -164,8 +164,8 @@ tasks:
     walletPrivkey: "tasks.test_wallet.outputs.childWallet.privkey"
     mnemonic: "tasks.test_mnemonic.outputs.mnemonic"
     depositContract: "depositContract"
-    # 0x03 builder credentials: version byte + 11 zero bytes + 20-byte address
-    withdrawalCredentials: '| "0x03" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
+    # 0xB0 builder credentials: version byte + 11 zero bytes + 20-byte address
+    withdrawalCredentials: '| "0xB0" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
 
 ##
 ## PHASE 1b: POST-FORK deposits

--- a/playbooks/gloas-dev/builder-prefork-onboard.yaml
+++ b/playbooks/gloas-dev/builder-prefork-onboard.yaml
@@ -1,5 +1,5 @@
 id: builder-prefork-onboard
-name: "GLOAS: Pre-fork builder onboarding (0x03 -> builder via fork dequeue)"
+name: "GLOAS: Pre-fork builder onboarding (0xB0 -> builder via fork dequeue)"
 description: |
   Focused regression test for the GLOAS pre-fork builder onboarding path
   (`onboard_builders_from_pending_deposits`).
@@ -10,7 +10,7 @@ description: |
 
   1. Inside the UNFINALIZED window just before GLOAS activates (so the deposit is
      still in state.pending_deposits at the fork), deposit `builderCount` keys via
-     the STANDARD validator deposit contract using 0x03 (builder) withdrawal
+     the STANDARD validator deposit contract using 0xB0 (builder) withdrawal
      credentials. The deposit signatures are verified under the regular
      DOMAIN_DEPOSIT, so the ordinary `generate_deposits` task is used unchanged.
   2. Because these deposits reach the fork still pending (unprocessed), the GLOAS
@@ -39,7 +39,7 @@ tags: [gloas, builder, deposit, onboarding, prefork, eip-8282]
 timeout: 1h
 config:
   walletPrivkey: ''
-  # Regular validator deposit contract (pre-fork builder onboarding via 0x03 creds).
+  # Regular validator deposit contract (pre-fork builder onboarding via 0xB0 creds).
   depositContract: '0x00000000219ab540356cBB839Cbe05303d7705Fa'
   builderCount: 5
   depositAmount: 5
@@ -98,7 +98,7 @@ tasks:
         echo "  current slot:        $CURRENT_SLOT"
         echo "  latest deposit slot: $LATEST_DEPOSIT_SLOT"
         echo "  GLOAS activation:    slot $ACTIVATION_SLOT (epoch $GLOAS_FORK_EPOCH)"
-        echo "Start the test earlier so the 0x03 deposit is still pending"
+        echo "Start the test earlier so the 0xB0 deposit is still pending"
         echo "(and unfinalized) when GLOAS activates."
         exit 1
       fi
@@ -143,7 +143,7 @@ tasks:
 ##
 ## PHASE 1: PRE-FORK deposit via the STANDARD validator deposit contract
 ##  Wait into the unfinalized window (~1 epoch before the fork), then deposit
-##  builderCount keys with 0x03 credentials so they are still pending (and
+##  builderCount keys with 0xB0 credentials so they are still pending (and
 ##  unfinalized, hence not yet drained into the validator registry) at the fork.
 ##
 
@@ -155,7 +155,7 @@ tasks:
 
 - name: generate_deposits
   id: prefork_deposits
-  title: "Deposit ${builderCount} builders via STANDARD contract (0x03 creds)"
+  title: "Deposit ${builderCount} builders via STANDARD contract (0xB0 creds)"
   config:
     awaitReceipt: true
     failOnReject: true
@@ -167,8 +167,8 @@ tasks:
     walletPrivkey: "tasks.test_wallet.outputs.childWallet.privkey"
     mnemonic: '| if .builderMnemonic != "" then .builderMnemonic else .tasks.test_mnemonic.outputs.mnemonic end'
     depositContract: "depositContract"
-    # 0x03 builder credentials: version byte + 11 zero bytes + 20-byte address
-    withdrawalCredentials: '| "0x03" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
+    # 0xB0 builder credentials: version byte + 11 zero bytes + 20-byte address
+    withdrawalCredentials: '| "0xB0" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
 
 ##
 ## PHASE 2: Verify the fork DEQUEUED the pending deposits into builders

--- a/playbooks/gloas-dev/builder-prefork-queuefill.yaml
+++ b/playbooks/gloas-dev/builder-prefork-queuefill.yaml
@@ -20,7 +20,7 @@ description: |
   Construction:
     1. In epoch F-3, deposit `junkCount` (>= 16) regular 0x01 deposits of 1 ETH as
        a "wall" at the front of the pending-deposit queue.
-    2. Right after (later slot, same epoch F-3), deposit the 0x03 builder deposit,
+    2. Right after (later slot, same epoch F-3), deposit the 0xB0 builder deposit,
        so it sits BEHIND the wall, at queue index >= junkCount.
     3. At the F-1 -> F boundary, process_pending_deposits finalizes everything,
        drains the first 16 (wall), hits the count cap, and stops BEFORE the builder
@@ -33,7 +33,7 @@ description: |
   FAIL on the active check => trick did not achieve slot-0 activation (logs show
        deposit_epoch vs finalized_epoch; usually means it slipped to F+1).
   FAIL on the onboard check => builder deposit was drained into a validator
-       (wall too small / mistimed) and is now a stuck 0x03 validator.
+       (wall too small / mistimed) and is now a stuck 0xB0 validator.
 
   Requires being started before epoch F-3 and GLOAS_FORK_EPOCH >= 3.
 version: 1.0.0
@@ -182,7 +182,7 @@ tasks:
 
 - name: generate_deposits
   id: builder_deposit
-  title: "Builder deposit (0x03) BEHIND the wall (index >= ${junkCount})"
+  title: "Builder deposit (0xB0) BEHIND the wall (index >= ${junkCount})"
   config:
     awaitReceipt: true
     awaitInclusion: true
@@ -196,8 +196,8 @@ tasks:
     walletPrivkey: "tasks.test_wallet.outputs.childWallet.privkey"
     mnemonic: '| if .builderMnemonic != "" then .builderMnemonic else .tasks.builder_mnemonic_rand.outputs.mnemonic end'
     depositContract: "depositContract"
-    # 0x03 builder credentials.
-    withdrawalCredentials: '| "0x03" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
+    # 0xB0 builder credentials.
+    withdrawalCredentials: '| "0xB0" + ("00" * 11) + (.tasks.test_wallet.outputs.childWallet.address | ltrimstr("0x"))'
 
 ##
 ## PHASE 3: at the first gloas block, the builder deposit must have been onboarded

--- a/playbooks/gloas-dev/exit-builders.yaml
+++ b/playbooks/gloas-dev/exit-builders.yaml
@@ -5,7 +5,7 @@ description: |
 
   The queue-fill run deposits `builderCount` builders (EIP-8282) from a fresh
   random mnemonic (its `builder_mnemonic` task output), funded by a child wallet
-  derived from the `gloas-prefork-public-builders` seed. The builders' 0x03
+  derived from the `gloas-prefork-public-builders` seed. The builders' 0xB0
   withdrawal credentials embed that wallet address, so only that wallet may exit
   them.
 
@@ -39,7 +39,7 @@ tasks:
     minClientCount: 1
 
 # Regenerate the builder wallet from the same seed used by prefork-queue-fill-public.
-# This wallet holds the 0x03 execution address authorized to exit the builders.
+# This wallet holds the 0xB0 execution address authorized to exit the builders.
 - name: generate_child_wallet
   id: builder_wallet
   title: "Regenerate builder wallet (exit sender)"

--- a/playbooks/gloas-dev/prefork-queue-fill-public.yaml
+++ b/playbooks/gloas-dev/prefork-queue-fill-public.yaml
@@ -10,9 +10,9 @@ description: |
   2. Deposit a set of validators with a mixed credential set
      (0x02 first so keys 0..N are compounding, then 0x01, then 0x00) from a
      fresh mnemonic.
-  3. Deposit builders (0x03 credentials via the regular deposit contract),
+  3. Deposit builders (0xB0 credentials via the regular deposit contract),
      batched - submitted AFTER the regular deposits so they sit at the END of the
-     pending-deposit queue. Pre-fork, 0x03 deposits that reach the fork still
+     pending-deposit queue. Pre-fork, 0xB0 deposits that reach the fork still
      pending are onboarded as builders at activation.
   4. Wait until `withdrawalLeadSlots` (10) slots before activation.
   5. Submit 100 EL-triggered partial withdrawal requests (1 gwei each) for
@@ -45,7 +45,7 @@ config:
   newValidatorDepCount00: 20   # 0x00 BLS         (keys 40..59)
   validatorDepositAmount: 32   # ETH per new validator
 
-  # Builder deposits (0x03 credentials via the regular deposit contract), batched, queued last.
+  # Builder deposits (0xB0 credentials via the regular deposit contract), batched, queued last.
   builderCount: 500
   builderDepositAmount: 1      # ETH per builder
   builderBatchSize: 100
@@ -136,7 +136,7 @@ tasks:
     privateKey: "walletPrivkey"
     prefundMinBalance: "| ((.newValidatorDepCount00 + .newValidatorDepCount01 + .newValidatorDepCount02) * .validatorDepositAmount + 50) * 1000000000000000000"
 
-# wallet that funds the builder deposits + holds the 0x03 address
+# wallet that funds the builder deposits + holds the 0xB0 address
 - name: generate_child_wallet
   id: builder_wallet
   title: "Generate wallet funding the builder deposits"
@@ -214,14 +214,14 @@ tasks:
         depositContract: "depositContract"
 
 ##
-## Builder deposits (0x03) - queued LAST.
+## Builder deposits (0xB0) - queued LAST.
 ##  Submitted only after the regular validator deposits have execution-layer
 ##  receipts, so their deposit requests land in later EL blocks and sit at the
 ##  END of the pending-deposit queue.
 ##
 
 - name: generate_batch_deposits
-  title: "Deposit ${builderCount} builders (0x03) in batches of ${builderBatchSize} (queued last)"
+  title: "Deposit ${builderCount} builders (0xB0) in batches of ${builderBatchSize} (queued last)"
   timeout: 30m
   config:
     awaitReceipt: true
@@ -233,12 +233,12 @@ tasks:
     depositAmount: "builderDepositAmount"
     walletPrivkey: "tasks.builder_wallet.outputs.childWallet.privkey"
     mnemonic: "tasks.builder_mnemonic.outputs.mnemonic"
-    # Pre-fork builders go through the REGULAR deposit contract with 0x03 creds;
+    # Pre-fork builders go through the REGULAR deposit contract with 0xB0 creds;
     # they are onboarded as builders at the fork (the EIP-8282 builder contract
     # rejects submissions before activation).
     depositContract: "depositContract"
-    # 0x03 builder credentials: version byte + 11 zero bytes + 20-byte address
-    withdrawalCredentials: '| "0x03" + ("00" * 11) + (.tasks.builder_wallet.outputs.childWallet.address | ltrimstr("0x"))'
+    # 0xB0 builder credentials: version byte + 11 zero bytes + 20-byte address
+    withdrawalCredentials: '| "0xB0" + ("00" * 11) + (.tasks.builder_wallet.outputs.childWallet.address | ltrimstr("0x"))'
 
 ##
 ## Gate: wait until `withdrawalLeadSlots` slots before GLOAS activation

--- a/playbooks/gloas-dev/prefork-queue-fill.yaml
+++ b/playbooks/gloas-dev/prefork-queue-fill.yaml
@@ -19,10 +19,10 @@ description: |
      0x01 -> 0x02 (compounding) credentials.
   5. Submit 100 consolidation requests (sources 50-149) targeting the now
      0x02 keys 0-49 (2 sources per target).
-  6. Deposit 1000 builders (0x03 credentials) from a second fresh mnemonic,
+  6. Deposit 1000 builders (0xB0 credentials) from a second fresh mnemonic,
      batched 100-per-tx via the REGULAR deposit contract. Pre-fork, builders are
      seeded this way (not via the EIP-8282 builder contract, which only accepts
-     submissions after activation): 0x03-credentialed deposits that reach the
+     submissions after activation): 0xB0-credentialed deposits that reach the
      fork still pending are onboarded as builders by
      onboard_builders_from_pending_deposits.
   7. Wait until 10 slots before GLOAS activation.
@@ -63,7 +63,7 @@ config:
   newValidatorDepCount02: 33   # 0x02 compounding credentials
   validatorDepositAmount: 32   # ETH per new validator
 
-  # Builder deposits (0x03 credentials via the regular deposit contract), batched.
+  # Builder deposits (0xB0 credentials via the regular deposit contract), batched.
   builderCount: 1000
   builderDepositAmount: 1      # ETH per builder
   builderBatchSize: 100
@@ -173,7 +173,7 @@ tasks:
     privateKey: "walletPrivkey"
     prefundMinBalance: "| ((.newValidatorDepCount00 + .newValidatorDepCount01 + .newValidatorDepCount02) * .validatorDepositAmount + 50) * 1000000000000000000"
 
-# wallet that funds the builder deposits + holds the 0x03 address
+# wallet that funds the builder deposits + holds the 0xB0 address
 - name: generate_child_wallet
   id: builder_wallet
   title: "Generate wallet funding the 1000 builder deposits"
@@ -198,7 +198,7 @@ tasks:
 ##  Stream A: 100 new validator deposits (mixed creds)
 ##  Stream C: BLS changes -> self-consolidations -> targeted consolidations
 ##
-## The 1000 builder deposits (0x03) are deliberately NOT in this concurrent
+## The 1000 builder deposits (0xB0) are deliberately NOT in this concurrent
 ## block: they run afterwards (see below) so they land in later EL blocks and
 ## sit at the END of the pending-deposit queue, behind the 100 regular
 ## validators. Stream C touches the consolidation/BLS queues only, so it does
@@ -333,7 +333,7 @@ tasks:
                 walletPrivkey: "tasks.req_wallet.outputs.childWallet.privkey"
 
 ##
-## Builder deposits (0x03) - queued LAST.
+## Builder deposits (0xB0) - queued LAST.
 ##  Runs only after the concurrent block above completes, i.e. after all 100
 ##  regular validator deposits have execution-layer receipts (awaitReceipt).
 ##  Because deposit-queue order follows EL block inclusion order, submitting
@@ -342,7 +342,7 @@ tasks:
 ##
 
 - name: generate_batch_deposits
-  title: "Deposit ${builderCount} builders (0x03) in batches of ${builderBatchSize} (queued last)"
+  title: "Deposit ${builderCount} builders (0xB0) in batches of ${builderBatchSize} (queued last)"
   timeout: 45m
   config:
     awaitReceipt: true
@@ -354,12 +354,12 @@ tasks:
     depositAmount: "builderDepositAmount"
     walletPrivkey: "tasks.builder_wallet.outputs.childWallet.privkey"
     mnemonic: "tasks.builder_mnemonic.outputs.mnemonic"
-    # Pre-fork builders go through the REGULAR deposit contract with 0x03 creds;
+    # Pre-fork builders go through the REGULAR deposit contract with 0xB0 creds;
     # they are onboarded as builders at the fork (the EIP-8282 builder contract
     # rejects submissions before activation).
     depositContract: "depositContract"
-    # 0x03 builder credentials: version byte + 11 zero bytes + 20-byte address
-    withdrawalCredentials: '| "0x03" + ("00" * 11) + (.tasks.builder_wallet.outputs.childWallet.address | ltrimstr("0x"))'
+    # 0xB0 builder credentials: version byte + 11 zero bytes + 20-byte address
+    withdrawalCredentials: '| "0xB0" + ("00" * 11) + (.tasks.builder_wallet.outputs.childWallet.address | ltrimstr("0x"))'
 
 ##
 ## Gate: wait until `withdrawalLeadSlots` slots before GLOAS activation


### PR DESCRIPTION
`BUILDER_WITHDRAWAL_PREFIX` changed from `0x03` to `0xB0` in ethereum/consensus-specs#5416 (lands in v1.7.0-alpha.12, targeted by glamsterdam-devnet-7).

- `generate_builder_deposits`: derived credentials now use `0xB0` (`creds[0] = 0xB0`)
- config `desc` strings and task READMEs updated (`generate_builder_deposits`, `generate_builder_exits`, `generate_batch_deposits`, `check_consensus_block_proposals`)
- all `playbooks/gloas-dev/*` that build credentials inline (`"0xB0" + ("00" * 11) + address`) and `playbooks/_index.yaml` descriptions

Note: after this merges, the gloas-dev playbooks only produce valid builder deposits on networks running v1.7.0-alpha.12+ rules (devnet-7); on devnet-6 (alpha.11, `0x03`) they would onboard nothing.

`go build ./...` and `go test ./pkg/tasks/...` pass.