### PR TITLE
bump go-eth2-client to v0.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.17.3
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.5
+	github.com/ethpandaops/go-eth2-client v0.1.6
 	github.com/ethpandaops/service-authenticatoor v0.0.1
 	github.com/ethpandaops/spamoor v1.2.1
 	github.com/glebarez/go-sqlite v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/ethereum/go-ethereum v1.17.3 h1:Ev/sQHH+UdKZHWjuVzhu2pxhi/sXaPZl23Q+Q
 github.com/ethereum/go-ethereum v1.17.3/go.mod h1:f2EhRwqewIZkGoQekywI2Y2RZAMTSavLNkD9qItFy1A=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.5 h1:MaWQ+KT+p7g+Lkx7pVuS+7omOAPYAKvtHXzGP8FjXTM=
-github.com/ethpandaops/go-eth2-client v0.1.5/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
+github.com/ethpandaops/go-eth2-client v0.1.6 h1:lG7Xz767YQQ+mN1ldzqJlj9Klg6zOElcemjXbCgJV5o=
+github.com/ethpandaops/go-eth2-client v0.1.6/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
 github.com/ethpandaops/service-authenticatoor v0.0.1 h1:yZ0gKYf+kkj92piqqYprpF6HkhEIhCNmzDrsYth92KI=
 github.com/ethpandaops/service-authenticatoor v0.0.1/go.mod h1:+C6sQMBxY2E3u6BITSZakQrGRovNnB1CamuQh/RIaXI=
 github.com/ethpandaops/spamoor v1.2.1 h1:ndCCKVehEB9t8O7/wnpZfqQ846uiknX1IQ10Di/2vAE=


### PR DESCRIPTION
Bumps ethpandaops/go-eth2-client v0.1.5 → v0.1.6, which includes the EIP-7688 progressive SSZ types for gloas (consensus-specs v1.7.0-alpha.12, go-eth2-client#34) and the payload envelope JSON unwrap fix (go-eth2-client#36). Build and tests pass.

buildoor, dora, and eth-beacon-genesis `glamsterdam-devnet-7` branches were bumped to v0.1.6 directly; assertoor has no devnet branch so this goes through master.