### PR TITLE
Remove dead code in dispatcher Unsubscribe so subscriptions are freed

### DIFF
--- a/pkg/clients/consensus/subscriptions.go
+++ b/pkg/clients/consensus/subscriptions.go
@@ -41,7 +41,7 @@ func (d *Dispatcher[T]) Unsubscribe(subscription *Subscription[T]) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if subscription.dispatcher != nil {
+	if subscription.dispatcher == nil {
 		return
 	}
 

--- a/pkg/clients/consensus/subscriptions_test.go
+++ b/pkg/clients/consensus/subscriptions_test.go
@@ -1,0 +1,56 @@
+package consensus
+
+import "testing"
+
+// TestDispatcherUnsubscribeRemovesSubscription verifies that Unsubscribe actually
+// removes the subscription from the dispatcher. A regression here means every
+// subscription leaks and Fire keeps delivering to and iterating over dead entries.
+func TestDispatcherUnsubscribeRemovesSubscription(t *testing.T) {
+	d := &Dispatcher[int]{}
+
+	subs := make([]*Subscription[int], 5)
+	for i := range subs {
+		subs[i] = d.Subscribe(1)
+	}
+
+	if got := len(d.subscriptions); got != 5 {
+		t.Fatalf("after subscribing 5: got %d subscriptions, want 5", got)
+	}
+
+	// remove two, including one that is not the last element
+	subs[1].Unsubscribe()
+	subs[3].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 3 {
+		t.Fatalf("after unsubscribing 2: got %d subscriptions, want 3", got)
+	}
+
+	// unsubscribing again must be a safe no-op
+	subs[1].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 3 {
+		t.Fatalf("after double unsubscribe: got %d subscriptions, want 3", got)
+	}
+
+	// Fire must only reach the still-subscribed channels
+	d.Fire(42)
+
+	for i, s := range subs {
+		want := 0
+		if i == 0 || i == 2 || i == 4 {
+			want = 1
+		}
+
+		if got := len(s.channel); got != want {
+			t.Fatalf("subscription %d: got %d buffered events, want %d", i, got, want)
+		}
+	}
+
+	subs[0].Unsubscribe()
+	subs[2].Unsubscribe()
+	subs[4].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 0 {
+		t.Fatalf("after unsubscribing all: got %d subscriptions, want 0", got)
+	}
+}

--- a/pkg/clients/execution/subscriptions.go
+++ b/pkg/clients/execution/subscriptions.go
@@ -41,7 +41,7 @@ func (d *Dispatcher[T]) Unsubscribe(subscription *Subscription[T]) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if subscription.dispatcher != nil {
+	if subscription.dispatcher == nil {
 		return
 	}
 

--- a/pkg/clients/execution/subscriptions_test.go
+++ b/pkg/clients/execution/subscriptions_test.go
@@ -1,0 +1,56 @@
+package execution
+
+import "testing"
+
+// TestDispatcherUnsubscribeRemovesSubscription verifies that Unsubscribe actually
+// removes the subscription from the dispatcher. A regression here means every
+// subscription leaks and Fire keeps delivering to and iterating over dead entries.
+func TestDispatcherUnsubscribeRemovesSubscription(t *testing.T) {
+	d := &Dispatcher[int]{}
+
+	subs := make([]*Subscription[int], 5)
+	for i := range subs {
+		subs[i] = d.Subscribe(1)
+	}
+
+	if got := len(d.subscriptions); got != 5 {
+		t.Fatalf("after subscribing 5: got %d subscriptions, want 5", got)
+	}
+
+	// remove two, including one that is not the last element
+	subs[1].Unsubscribe()
+	subs[3].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 3 {
+		t.Fatalf("after unsubscribing 2: got %d subscriptions, want 3", got)
+	}
+
+	// unsubscribing again must be a safe no-op
+	subs[1].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 3 {
+		t.Fatalf("after double unsubscribe: got %d subscriptions, want 3", got)
+	}
+
+	// Fire must only reach the still-subscribed channels
+	d.Fire(42)
+
+	for i, s := range subs {
+		want := 0
+		if i == 0 || i == 2 || i == 4 {
+			want = 1
+		}
+
+		if got := len(s.channel); got != want {
+			t.Fatalf("subscription %d: got %d buffered events, want %d", i, got, want)
+		}
+	}
+
+	subs[0].Unsubscribe()
+	subs[2].Unsubscribe()
+	subs[4].Unsubscribe()
+
+	if got := len(d.subscriptions); got != 0 {
+		t.Fatalf("after unsubscribing all: got %d subscriptions, want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem

The subscription dispatcher's `Unsubscribe` returned early on the wrong condition:

```go
if subscription.dispatcher != nil {
    return
}
```

A live subscription always has `dispatcher` set (it is assigned in `Subscribe` and only cleared inside the removal block that follows this guard), so the guard always returned and the removal loop below it was dead code. No subscription was ever removed.

The block, slot, epoch, payload and finalized event subscriptions created by the check and generate tasks each run `defer subscription.Unsubscribe()`, so every one of those was a no-op. On a long running instance the effects compound:

- The dispatcher's `subscriptions` slice grows without bound.
- `Fire` runs on every block, slot and epoch and iterates the whole slice under its mutex, so per event work grows with the number of leaked entries.
- Each leaked subscription keeps a buffered channel that nobody drains, so it pins up to `capacity` block objects in memory for the lifetime of the process.

Together this trends toward memory and cpu exhaustion.

## Fix

Invert the guard so an already removed subscription (`dispatcher == nil`) is the early return, and a live subscription actually reaches the removal loop. The wrapper `Subscription.Unsubscribe` already guards double calls, so this remains safe to call more than once.

The dispatcher is duplicated in the execution and consensus client packages, so the same one character fix is applied to both.

## Tests

Each package gets a test that drives the real `Subscribe`, `Unsubscribe` and `Fire`, and asserts that removal shrinks the slice, that `Fire` only reaches still subscribed channels, that a repeated unsubscribe is a safe no-op, and that unsubscribing everything leaves the dispatcher empty. The test fails against the old guard and passes with the fix.

`go build ./...`, `go vet`, and the client package tests pass.