### PR TITLE
Enforce maxTotalReorgs in the consensus reorg check

### DIFF
--- a/pkg/tasks/check_consensus_reorgs/task.go
+++ b/pkg/tasks/check_consensus_reorgs/task.go
@@ -159,6 +159,11 @@ func (t *Task) runCheck() types.TaskResult {
 
 	epochCount := currentEpoch.Number() - t.startEpoch
 
+	return t.evaluateReorgs(epochCount)
+}
+
+// evaluateReorgs applies the configured reorg thresholds to the observed counts.
+func (t *Task) evaluateReorgs(epochCount uint64) types.TaskResult {
 	if t.config.MinCheckEpochCount > 0 && epochCount < t.config.MinCheckEpochCount {
 		t.logger.Warnf("Check missed: checked %v epochs, but need >= %v", epochCount, t.config.MinCheckEpochCount)
 		return types.TaskResultNone
@@ -166,6 +171,11 @@ func (t *Task) runCheck() types.TaskResult {
 
 	if t.config.MaxReorgsPerEpoch > 0 && epochCount > 0 && float64(t.totalReorgs)/float64(epochCount) > t.config.MaxReorgsPerEpoch {
 		t.logger.Warnf("check failed: max reorgs per epoch exceeded. (have: %v, want <= %v)", float64(t.totalReorgs)/float64(epochCount), t.config.MaxReorgsPerEpoch)
+		return types.TaskResultFailure
+	}
+
+	if t.config.MaxTotalReorgs > 0 && t.totalReorgs > t.config.MaxTotalReorgs {
+		t.logger.Warnf("check failed: max total reorgs exceeded. (have: %v, want <= %v)", t.totalReorgs, t.config.MaxTotalReorgs)
 		return types.TaskResultFailure
 	}
 

--- a/pkg/tasks/check_consensus_reorgs/task_test.go
+++ b/pkg/tasks/check_consensus_reorgs/task_test.go
@@ -1,0 +1,63 @@
+package checkconsensusreorgs
+
+import (
+	"io"
+	"testing"
+
+	"github.com/ethpandaops/assertoor/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+func newEvalTask(cfg Config, totalReorgs uint64) *Task {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	return &Task{
+		config:      cfg,
+		logger:      log,
+		totalReorgs: totalReorgs,
+	}
+}
+
+// TestEvaluateReorgsMaxTotal covers the maxTotalReorgs bound, which was declared and
+// documented but never enforced, so a run exceeding it still passed.
+func TestEvaluateReorgsMaxTotal(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxTotal    uint64
+		totalReorgs uint64
+		epochCount  uint64
+		want        types.TaskResult
+	}{
+		{"under the bound passes", 5, 3, 10, types.TaskResultSuccess},
+		{"at the bound passes", 5, 5, 10, types.TaskResultSuccess},
+		{"over the bound fails", 5, 6, 10, types.TaskResultFailure},
+		{"unset bound is ignored", 0, 1000, 10, types.TaskResultSuccess},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := newEvalTask(Config{MaxTotalReorgs: tc.maxTotal}, tc.totalReorgs)
+
+			if got := task.evaluateReorgs(tc.epochCount); got != tc.want {
+				t.Fatalf("maxTotalReorgs=%d totalReorgs=%d: got %v, want %v", tc.maxTotal, tc.totalReorgs, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateReorgsOtherBounds guards the neighbouring thresholds so the added
+// check does not shadow them.
+func TestEvaluateReorgsOtherBounds(t *testing.T) {
+	// minCheckEpochCount not yet reached -> inconclusive
+	task := newEvalTask(Config{MinCheckEpochCount: 5}, 0)
+	if got := task.evaluateReorgs(2); got != types.TaskResultNone {
+		t.Fatalf("min epoch not reached: got %v, want None", got)
+	}
+
+	// maxReorgsPerEpoch exceeded -> failure
+	task = newEvalTask(Config{MaxReorgsPerEpoch: 1.0}, 30)
+	if got := task.evaluateReorgs(10); got != types.TaskResultFailure {
+		t.Fatalf("max reorgs per epoch exceeded: got %v, want Failure", got)
+	}
+}


### PR DESCRIPTION
## Problem

`check_consensus_reorgs` documents a `maxTotalReorgs` option to bound the total number of reorgs observed during monitoring, but the field was never read. `runCheck` only enforced `minCheckEpochCount` and `maxReorgsPerEpoch` (and `maxReorgDistance` is handled separately). A playbook that set `maxTotalReorgs` to gate on total reorgs therefore had no effect: the check reported success no matter how many reorgs accumulated.

## Fix

Evaluate `maxTotalReorgs` alongside the other reorg thresholds, and extract the threshold evaluation into a helper so it can be unit tested without the wall clock service.

## Tests

Table test over the new bound (under, at, over, and unset), plus a guard for the neighbouring thresholds so the added check does not shadow them.

`go build ./...`, `go vet`, and the package tests pass.